### PR TITLE
Add api/auth/register

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/config/AuthConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/config/AuthConfig.kt
@@ -1,0 +1,28 @@
+package com.wafflestudio.toyproject.team4.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+class AuthConfig {
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+
+    @Bean
+    fun securityFilterChain(httpSecurity: HttpSecurity): SecurityFilterChain =
+        httpSecurity
+            .csrf().disable()
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            .authorizeRequests()
+            .anyRequest().permitAll()
+            .and()
+            .build()
+
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.toyproject.team4.core.user.api
+
+import com.wafflestudio.toyproject.team4.core.user.api.request.RegisterRequest
+import com.wafflestudio.toyproject.team4.core.user.service.AuthService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import javax.transaction.Transactional
+
+
+@RestController
+class AuthController (
+    private val authService: AuthService
+){
+    
+    @Transactional
+    @PostMapping("api/auth/register")
+    fun register(
+        @RequestBody request: RegisterRequest
+    ) = authService.register(request)
+    
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
@@ -18,6 +18,6 @@ class AuthController (
     @Transactional
     @PostMapping("api/auth/register")
     fun register(
-        @RequestBody request: RegisterRequest
-    ) = ResponseEntity(authService.register(request), HttpStatus.CREATED)
+        @RequestBody registerRequest: RegisterRequest
+    ) = ResponseEntity(authService.register(registerRequest), HttpStatus.CREATED)
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
@@ -6,18 +6,20 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import javax.transaction.Transactional
 
 
 @RestController
+@RequestMapping("/api/auth")
 class AuthController (
     private val authService: AuthService
 ){
     
     @Transactional
-    @PostMapping("api/auth/register")
+    @PostMapping("/register")
     fun register(
-        @RequestBody request: RegisterRequest
-    ) = ResponseEntity(authService.register(request), HttpStatus.CREATED)
+        @RequestBody registerRequest: RegisterRequest
+    ) = ResponseEntity(authService.register(registerRequest), HttpStatus.CREATED)
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
@@ -2,6 +2,8 @@ package com.wafflestudio.toyproject.team4.core.user.api
 
 import com.wafflestudio.toyproject.team4.core.user.api.request.RegisterRequest
 import com.wafflestudio.toyproject.team4.core.user.service.AuthService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -17,6 +19,5 @@ class AuthController (
     @PostMapping("api/auth/register")
     fun register(
         @RequestBody request: RegisterRequest
-    ) = authService.register(request)
-    
+    ) = ResponseEntity(authService.register(request), HttpStatus.CREATED)
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/request/RegisterRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/request/RegisterRequest.kt
@@ -7,6 +7,6 @@ data class RegisterRequest(
     val password: String,
     val nickname: String
 ) {
-    fun toUserEntity(encodedPwd: String): UserEntity
-    = UserEntity(username, encodedPwd, nickname)
+    fun toUserEntity(encodedPassword: String): UserEntity
+    = UserEntity(username, encodedPassword, nickname)
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/request/RegisterRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/request/RegisterRequest.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.toyproject.team4.core.user.api.request
 
-import com.wafflestudio.toyproject.team4.core.user.domain.UserEntity
+import com.wafflestudio.toyproject.team4.core.user.database.UserEntity
 
 data class RegisterRequest(
     val username: String,

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/request/RegisterRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/request/RegisterRequest.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.toyproject.team4.core.user.api.request
+
+import com.wafflestudio.toyproject.team4.core.user.domain.UserEntity
+
+data class RegisterRequest(
+    val username: String,
+    val password: String,
+    val nickname: String
+) {
+    fun toUserEntity(encodedPwd: String): UserEntity
+    = UserEntity(username, encodedPwd, nickname)
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserEntity.kt
@@ -13,7 +13,7 @@ class UserEntity (
     val username: String,
     var encodedPassword: String,
     var nickname: String,
-    var imageURL: String? = null,
+    var imageUrl: String? = null,
     var reviewCount: Long? = 0L,
     
     val sex: String? = null,

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserEntity.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.toyproject.team4.core.user.domain
+package com.wafflestudio.toyproject.team4.core.user.database
 
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserRepository.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.toyproject.team4.core.user.database
 
-import com.wafflestudio.toyproject.team4.core.user.domain.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository: JpaRepository<UserEntity, Long>

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserRepository.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.toyproject.team4.core.user.database
+
+import com.wafflestudio.toyproject.team4.core.user.domain.UserEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserRepository: JpaRepository<UserEntity, Long>

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/domain/UserEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/domain/UserEntity.kt
@@ -27,5 +27,5 @@ class UserEntity (
     val id: Long = 0L
     
     @CreatedDate
-    val registrationDate: LocalDateTime = LocalDateTime.now()
+    var registrationDate: LocalDateTime = LocalDateTime.now()
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/domain/UserEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/domain/UserEntity.kt
@@ -1,0 +1,31 @@
+package com.wafflestudio.toyproject.team4.core.user.domain
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import javax.persistence.*
+
+
+@Entity
+@Table(name="users")
+@EntityListeners(AuditingEntityListener::class)
+class UserEntity (
+    val username: String,
+    var encodedPassword: String,
+    var nickname: String,
+    var imageURL: String? = null,
+    var reviewCount: Long? = 0L,
+    
+    val sex: String? = null,
+    var height: Long? = null,
+    var weight: Long? = null,
+    
+    var socialKey: String? = null,
+){
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+    
+    @CreatedDate
+    val registrationDate: LocalDateTime = LocalDateTime.now()
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
@@ -1,25 +1,25 @@
 package com.wafflestudio.toyproject.team4.core.user.service
 
-import com.wafflestudio.toyproject.team4.config.AuthConfig
 import com.wafflestudio.toyproject.team4.core.user.api.request.RegisterRequest
 import com.wafflestudio.toyproject.team4.core.user.database.UserRepository
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import javax.transaction.Transactional
 
 
 interface AuthService {
-    fun register(registerRequest: RegisterRequest)
+    fun register(request: RegisterRequest)
 }
 
 @Service
 class AuthServiceImpl(
-    private val passwordEncoder: PasswordEncoder
+    private val passwordEncoder: PasswordEncoder,
     private val userRepository: UserRepository
 ): AuthService {
     
     @Transactional
-    override fun register(registerRequest: RegisterRequest) {
-        val encodedPassword = passwordEncoder.encode(registerRequest.password)
+    override fun register(request: RegisterRequest) {
+        val encodedPassword = passwordEncoder.encode(request.password)
         userRepository.save(request.toUserEntity(encodedPassword))
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.toyproject.team4.core.user.service
+
+import com.wafflestudio.toyproject.team4.core.user.api.request.RegisterRequest
+import com.wafflestudio.toyproject.team4.core.user.database.UserRepository
+import org.springframework.stereotype.Service
+import javax.transaction.Transactional
+
+
+interface AuthService {
+    fun register(request: RegisterRequest)
+}
+
+@Service
+class AuthServiceImpl(
+    private val userRepository: UserRepository
+): AuthService {
+    
+    @Transactional
+    override fun register(request: RegisterRequest) {
+        userRepository.save(request.toUserEntity(request.password))
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
@@ -1,8 +1,8 @@
 package com.wafflestudio.toyproject.team4.core.user.service
 
-import com.wafflestudio.toyproject.team4.config.AuthConfig
 import com.wafflestudio.toyproject.team4.core.user.api.request.RegisterRequest
 import com.wafflestudio.toyproject.team4.core.user.database.UserRepository
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import javax.transaction.Transactional
 
@@ -13,13 +13,13 @@ interface AuthService {
 
 @Service
 class AuthServiceImpl(
-    private val authConfig: AuthConfig,
+    private val passwordEncoder: PasswordEncoder,
     private val userRepository: UserRepository
 ): AuthService {
     
     @Transactional
     override fun register(registerRequest: RegisterRequest) {
-        val encodedPwd = authConfig.passwordEncoder().encode(registerRequest.password)
-        userRepository.save(registerRequest.toUserEntity(encodedPwd))
+        val encodedPassword = passwordEncoder.encode(registerRequest.password)
+        userRepository.save(registerRequest.toUserEntity(encodedPassword))
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
@@ -8,7 +8,7 @@ import javax.transaction.Transactional
 
 
 interface AuthService {
-    fun register(request: RegisterRequest)
+    fun register(registerRequest: RegisterRequest)
 }
 
 @Service

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
@@ -13,7 +13,7 @@ interface AuthService {
 
 @Service
 class AuthServiceImpl(
-    private val authConfig: AuthConfig,
+    private val passwordEncoder: PasswordEncoder
     private val userRepository: UserRepository
 ): AuthService {
     

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.toyproject.team4.core.user.service
 
+import com.wafflestudio.toyproject.team4.config.AuthConfig
 import com.wafflestudio.toyproject.team4.core.user.api.request.RegisterRequest
 import com.wafflestudio.toyproject.team4.core.user.database.UserRepository
 import org.springframework.stereotype.Service
@@ -12,11 +13,13 @@ interface AuthService {
 
 @Service
 class AuthServiceImpl(
+    private val authConfig: AuthConfig,
     private val userRepository: UserRepository
 ): AuthService {
     
     @Transactional
     override fun register(request: RegisterRequest) {
-        userRepository.save(request.toUserEntity(request.password))
+        val encodedPwd = authConfig.passwordEncoder().encode(request.password)
+        userRepository.save(request.toUserEntity(encodedPwd))
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
@@ -18,8 +18,8 @@ class AuthServiceImpl(
 ): AuthService {
     
     @Transactional
-    override fun register(request: RegisterRequest) {
-        val encodedPassword = passwordEncoder.encode(request.password)
-        userRepository.save(request.toUserEntity(encodedPassword))
+    override fun register(registerRequest: RegisterRequest) {
+        val encodedPassword = passwordEncoder.encode(registerRequest.password)
+        userRepository.save(registerRequest.toUserEntity(encodedPassword))
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
@@ -18,8 +18,8 @@ class AuthServiceImpl(
 ): AuthService {
     
     @Transactional
-    override fun register(request: RegisterRequest) {
-        val encodedPassword = passwordEncoder.encode(request.password)
-        userRepository.save(request.toUserEntity(encodedPwd))
+    override fun register(registerRequest: RegisterRequest) {
+        val encodedPassword = passwordEncoder.encode(registerRequest.password)
+        userRepository.save(request.toUserEntity(encodedPassword))
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
@@ -19,7 +19,7 @@ class AuthServiceImpl(
     
     @Transactional
     override fun register(request: RegisterRequest) {
-        val encodedPwd = authConfig.passwordEncoder().encode(request.password)
+        val encodedPassword = passwordEncoder.encode(request.password)
         userRepository.save(request.toUserEntity(encodedPwd))
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthService.kt
@@ -8,7 +8,7 @@ import javax.transaction.Transactional
 
 
 interface AuthService {
-    fun register(request: RegisterRequest)
+    fun register(registerRequest: RegisterRequest)
 }
 
 @Service
@@ -18,8 +18,8 @@ class AuthServiceImpl(
 ): AuthService {
     
     @Transactional
-    override fun register(request: RegisterRequest) {
-        val encodedPwd = authConfig.passwordEncoder().encode(request.password)
-        userRepository.save(request.toUserEntity(encodedPwd))
+    override fun register(registerRequest: RegisterRequest) {
+        val encodedPwd = authConfig.passwordEncoder().encode(registerRequest.password)
+        userRepository.save(registerRequest.toUserEntity(encodedPwd))
     }
 }


### PR DESCRIPTION
# `/api/auth/register`
유저 아이디, 닉네임에 대한 중복 확인이 모두 이루어진 다음에 회원가입 버튼이 활성화되는 방식을 생각하고 있으니,
해당 field에 대한 중복으로 인한 exception은 고려하지 않았습니다.

## 구현 사항
### ✅ DB에 유저 정보 추가
아래의 request body를 받았을 때 DB에 이 유저에 대한 새 행이 추가되도록 하였습니다.
(테이블명은 일단 `users` 로 했는데, 수정 필요하시면 코멘트 주세요 !! !)
``` {json}
{
    "username" : String,
    "password" : String,
    "nickname" : String
}
```
이때, request body로 전달된 password는 *PasswordEncoder* 를 통해 암호화시킨 다음, 이 **암호화된 비밀번호**를 DB에 저장하도록 했습니다.
그리고, 회원가입 시각(`registrationDate` field)는 **요청 시각**이 자동으로 들어가게끔 하였습니다. 뿐만 아니라, request body로 넘어오는 정보 + 회원가입 시각 외의 field는 전부 null 값이 들어가도록 했어요.

### ✅ Response Http Status
successful response에 대한 http status가 *201 Created* 가 되도록 설정하였습니다.

<br>
--- <br>
위 구현 사항에 대한 내용을 확인할 수 있는 예시 사진, 아래에 첨부합니다. <br>
확인 부탁드려요 ! <br>
<br>

**🧊  회원가입 요청 보내기**

<img src="https://user-images.githubusercontent.com/90292371/210129165-8c7d3b00-cb75-477d-afb5-50c5e56bfe05.png" width = "550">

**🧊  요청에 따른 users 테이블 확인**

<img src="https://user-images.githubusercontent.com/90292371/210129620-3ac0d0fa-8923-430b-bdc2-3ceda2f0ffe8.png">


## ETC: 질문..? 그 외 ..?!
### ❓ 예외 처리 관련
저희가 작성한 Rest API 문서를 보니 400, 405에 대한 예외 처리를 한다고 되어 있던데, 어떤 경우에 대한 예외 처리를 해야 할지 감이 잡히질 않아서요. 리뷰 시 해당 부분에 대한 의견 주시면 감사하겠습니다 🙏
: request method를 제대로 지정하지 않으면 아래 사진에서와 같이 405 에러가 뜨게 되는데, 그냥 뜨는 이 상태로 두면 되는 거겠죠 ..? 별도로 에러 메시지를 커스터마이즈 해야 하는 건가 싶어서 여쭤봅니다.

<img src="https://user-images.githubusercontent.com/90292371/210129278-83c40569-f799-4efa-b577-e6f6f62a74e8.png" width = "550">


### ❓ 로컬 DB와의 연결을 위한 설정
로컬 DB와의 연결을 위한 파일(`docker-compose.yml`, `application.yaml` 등)을 본 branch에 포함시키기엔 git flow와 맞지 않단 느낌이 들어서 본 PR에는 포함시키지 않았습니다.
회원가입 API를 구현하기 위한 branch인데, 로컬 DB와의 연결을 위한 건 본 branch를 판 목적과 부합하지 않는 것 같아서요
별도로 main 브랜치에 merge해두는 것도 나쁘지 않겠다 싶었네요 .. 🤔




