### PR TITLE
Add api/items

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.toyproject.team4.core.item.service.ItemService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 
@@ -18,4 +19,10 @@ class ItemController(
     fun getHomepage(
         @RequestBody itemRequest: ItemRequest
     ) = itemService.getItemRankingList(itemRequest)
+    
+    @GetMapping("/item/{id}")
+    fun getItem(
+        @RequestParam itemId: Long
+    ) = itemService.getItem(itemId)
+
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -2,11 +2,7 @@ package com.wafflestudio.toyproject.team4.core.item.api
 
 import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
 import com.wafflestudio.toyproject.team4.core.item.service.ItemService
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 
 @RestController
@@ -15,14 +11,14 @@ class ItemController(
     private val itemService: ItemService
 ) {
     
-    @GetMapping("/items/")
+    @GetMapping("/items")
     fun getHomepage(
         @RequestBody itemRequest: ItemRequest
     ) = itemService.getItemRankingList(itemRequest)
     
     @GetMapping("/item/{id}")
     fun getItem(
-        @RequestParam itemId: Long
+        @PathVariable(value="id") itemId: Long
     ) = itemService.getItem(itemId)
 
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.toyproject.team4.core.item.api
+
+import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
+import com.wafflestudio.toyproject.team4.core.item.service.ItemService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+@RequestMapping("/api")
+class ItemController(
+    private val itemService: ItemService
+) {
+    
+    @GetMapping("/items/")
+    fun getHomepage(
+        @RequestBody itemRequest: ItemRequest
+    ) = itemService.getItemRankingList(itemRequest)
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/request/ItemRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/request/ItemRequest.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.toyproject.team4.core.item.api.request
+
+data class ItemRequest(
+    val category: String? = null,
+    val nextItemId: Long? = null
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.toyproject.team4.core.item.api.response
+
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+
+data class ItemRankingResponse (
+    val items: List<Item>,
+    val nextItemId: Long
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
@@ -4,5 +4,5 @@ import com.wafflestudio.toyproject.team4.core.item.domain.Item
 
 data class ItemRankingResponse (
     val items: List<Item>,
-    val nextItemId: Long
+    val nextItemId: Long?
 )

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
@@ -19,9 +19,13 @@ class ItemEntity(
     val oldPrice: Long,
     var sale: Long? = 0L,
 
-    @ElementCollection(fetch=FetchType.LAZY) 
-    @Column(name="OptionsName")
-    val options: List<String>,
+    @OneToMany(
+        mappedBy = "item",
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true
+    )
+    val options: MutableList<OptionEntity>? = mutableListOf(),
     
     @Enumerated(EnumType.STRING)
     val category: Item.Category,

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
@@ -1,0 +1,41 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import javax.persistence.*
+
+@Entity
+@Table(name = "items")
+class ItemEntity(
+    val name: String,
+    val brand: String,
+    val imageUrl: String,
+
+    @Enumerated(EnumType.STRING)
+    val label: Item.Label? = null,
+    @Enumerated(EnumType.STRING)
+    val sex: Item.Sex,
+    val rating: Long? = 0L,
+
+    val oldPrice: Long,
+    var sale: Long? = 0L,
+
+    @ElementCollection(fetch=FetchType.LAZY) 
+    val options: List<String>,
+    
+    @Enumerated(EnumType.STRING)
+    val category: Item.Category,
+    @Enumerated(EnumType.STRING)
+    val subCategory: Item.SubCategory,
+
+    //"reviews": Review[],    # 구매후기
+    
+) {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+    
+    var newPrice: Long = (oldPrice * (1- sale!!) + 5) / 10 * 10
+    val nextItemId: Long = id + 10
+
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
@@ -20,6 +20,7 @@ class ItemEntity(
     var sale: Long? = 0L,
 
     @ElementCollection(fetch=FetchType.LAZY) 
+    @Column(name="OptionsName")
     val options: List<String>,
     
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Component
+
+interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositoryCustom {
+    fun findAllByCategoryOrderByRatingDesc(category: Item.Category): List<ItemEntity>
+    fun findAllByOrderByRatingDesc(): List<ItemEntity>
+}
+
+interface ItemRepositoryCustom
+
+@Component
+class ItemRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : ItemRepositoryCustom

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionEntity.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import javax.persistence.*
+
+@Entity
+@Table(name = "options")
+class OptionEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "itemId")
+    val item: ItemEntity,
+    
+    val optionName: String
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionRepository.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface OptionRepository : JpaRepository<OptionEntity, Long>

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
@@ -1,0 +1,53 @@
+package com.wafflestudio.toyproject.team4.core.item.domain
+
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
+
+data class Item (
+    val id: Long,
+    val name: String,
+    val brand: String,
+    val imageUrl: String,
+    val label: String,
+    val oldPrice: Long,
+    val newPrice: Long,
+    val sale: Long,
+) {
+    
+    enum class Label {
+        LIMITED, BOUTIQUE, PREORDER, EXCLUSIVE
+    }
+    
+    enum class Sex {
+        MALE, FEMALE, UNISEX
+    }
+    
+    enum class Category {
+        TOP, OUTER, PANTS, SKIRT, BAG, SHOES, HEADWEAR
+    }
+
+    enum class SubCategory {
+        SWEATER, HOODIE, SWEATSHIRT, SHIRT,  // TOP
+        COAT, JACKET, PADDING, CARDIGAN,     // OUTER
+        DENIM, SLACKS, JOGGER, LEGGINGS,     // PANTS
+        MINISKIRT, MEDISKIRT, LONGSKIRT,     // SKIRT
+        BACKPACK, CROSSBAG, ECHOBAG,         // BAG
+        GOODOO, SANDAL, SLIPPER, SNEAKERS,   // SHOES
+        CAP, HAT, BEANIE                     // HEADWEAR 
+    }
+    
+    
+    companion object {
+        fun of(entity: ItemEntity): Item = entity.run {
+            Item(
+                id = id,
+                name = name,
+                brand = brand,
+                imageUrl = imageUrl,
+                label = label.toString(),
+                oldPrice = oldPrice,
+                newPrice = newPrice,
+                sale = sale!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
@@ -7,7 +7,7 @@ data class Item (
     val name: String,
     val brand: String,
     val imageUrl: String,
-    val label: String,
+    val label: String?,
     val oldPrice: Long,
     val newPrice: Long,
     val sale: Long,

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -25,10 +25,10 @@ class ItemServiceImpl(
     override fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse {
         val category = itemRequest.category
         val rankingList = with(itemRepository) {
-            if (category == null) this.findAllByOrderByRatingDesc()
+            if (category.isNullOrEmpty()) this.findAllByOrderByRatingDesc()
             else this.findAllByCategoryOrderByRatingDesc(Item.Category.valueOf(category))
         }
-        val nextItemId = rankingList[0].nextItemId
+        val nextItemId = rankingList.firstOrNull()?.nextItemId
         
         return ItemRankingResponse(
             items = rankingList.map { entity -> Item.of(entity) },

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -1,15 +1,19 @@
 package com.wafflestudio.toyproject.team4.core.item.service
 
+import com.wafflestudio.toyproject.team4.common.CustomHttp404
 import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
 import com.wafflestudio.toyproject.team4.core.item.api.response.ItemRankingResponse
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
 import com.wafflestudio.toyproject.team4.core.item.database.ItemRepository
 import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 
 interface ItemService {
     fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse
+    fun getItem(itemId: Long): ItemEntity
 }
 
 @Service
@@ -30,5 +34,10 @@ class ItemServiceImpl(
             items = rankingList.map { entity -> Item.of(entity) },
             nextItemId = nextItemId
         )
+    }
+
+    override fun getItem(itemId: Long): ItemEntity {
+        return itemRepository.findByIdOrNull(itemId)
+            ?: throw CustomHttp404("존재하지 않는 상품 아이디입니다.")
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -1,0 +1,34 @@
+package com.wafflestudio.toyproject.team4.core.item.service
+
+import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
+import com.wafflestudio.toyproject.team4.core.item.api.response.ItemRankingResponse
+import com.wafflestudio.toyproject.team4.core.item.database.ItemRepository
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+
+interface ItemService {
+    fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse
+}
+
+@Service
+class ItemServiceImpl(
+    private val itemRepository: ItemRepository,
+) : ItemService {
+
+    @Transactional(readOnly = true)
+    override fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse {
+        val category = itemRequest.category
+        val rankingList = with(itemRepository) {
+            if (category == null) this.findAllByOrderByRatingDesc()
+            else this.findAllByCategoryOrderByRatingDesc(Item.Category.valueOf(category))
+        }
+        val nextItemId = rankingList[0].nextItemId
+        
+        return ItemRankingResponse(
+            items = rankingList.map { entity -> Item.of(entity) },
+            nextItemId = nextItemId
+        )
+    }
+}


### PR DESCRIPTION
`/api/items` 와 `/api/item/:id` 기능 구현이 어느 정도 마무리되어서 PR 올립니다 ~! 
아직 mock data로 테스트는 진행해보진 못했습니다 .. !

---
#### ❓ 의견 여쭙습니다 ,, 
ItemEntity의 `options` 필드가 String 어레이인데, RDB 특성상 필드값으로 array 타입이 불가능하다보니 별도의 테이블을 파야할 것 같습니다. 관련해서 찾아보니([**링크**](https://ttl-blog.tistory.com/121)) 값 타입 컬렉션을 사용하면 된다고 해서 **@ElementCollection** 어노테이션을 이용하는 방식으로 코드를 작성하긴 했지만, 이럴거면 아예 상품별로 option 정보를 모아둔 테이블을 하나 만드는 것도 나쁘지 않겠다 싶어서요 .. !
관련해서 편하게 의견 말씀해주시면 감사하겠습니다 🙇‍♀️ 