### PR TITLE
Add Mock-data generating class

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
 	implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
 	implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
+	// jsoup - Web Crawling
+	implementation("org.jsoup:jsoup:1.15.3")
 
 	// Kotlin Features
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.toyproject.team4.core.item.service.ItemService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 
@@ -18,4 +19,10 @@ class ItemController(
     fun getHomepage(
         @RequestBody itemRequest: ItemRequest
     ) = itemService.getItemRankingList(itemRequest)
+    
+    @GetMapping("/item/{id}")
+    fun getItem(
+        @RequestParam itemId: Long
+    ) = itemService.getItem(itemId)
+
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -2,11 +2,7 @@ package com.wafflestudio.toyproject.team4.core.item.api
 
 import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
 import com.wafflestudio.toyproject.team4.core.item.service.ItemService
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 
 @RestController
@@ -15,14 +11,14 @@ class ItemController(
     private val itemService: ItemService
 ) {
     
-    @GetMapping("/items/")
+    @GetMapping("/items")
     fun getHomepage(
         @RequestBody itemRequest: ItemRequest
     ) = itemService.getItemRankingList(itemRequest)
     
     @GetMapping("/item/{id}")
     fun getItem(
-        @RequestParam itemId: Long
+        @PathVariable(value="id") itemId: Long
     ) = itemService.getItem(itemId)
 
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.toyproject.team4.core.item.api
+
+import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
+import com.wafflestudio.toyproject.team4.core.item.service.ItemService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+@RequestMapping("/api")
+class ItemController(
+    private val itemService: ItemService
+) {
+    
+    @GetMapping("/items/")
+    fun getHomepage(
+        @RequestBody itemRequest: ItemRequest
+    ) = itemService.getItemRankingList(itemRequest)
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/request/ItemRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/request/ItemRequest.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.toyproject.team4.core.item.api.request
+
+data class ItemRequest(
+    val category: String? = null,
+    val nextItemId: Long? = null
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.toyproject.team4.core.item.api.response
+
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+
+data class ItemRankingResponse (
+    val items: List<Item>,
+    val nextItemId: Long
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
@@ -4,5 +4,5 @@ import com.wafflestudio.toyproject.team4.core.item.domain.Item
 
 data class ItemRankingResponse (
     val items: List<Item>,
-    val nextItemId: Long
+    val nextItemId: Long?
 )

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
@@ -19,9 +19,13 @@ class ItemEntity(
     val oldPrice: Long,
     var sale: Long? = 0L,
 
-    @ElementCollection(fetch=FetchType.LAZY) 
-    @Column(name="OptionsName")
-    val options: List<String>,
+    @OneToMany(
+        mappedBy = "item",
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true
+    )
+    val options: MutableList<OptionEntity>? = mutableListOf(),
     
     @Enumerated(EnumType.STRING)
     val category: Item.Category,

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
@@ -13,10 +13,11 @@ class ItemEntity(
     @Enumerated(EnumType.STRING)
     val label: Item.Label? = null,
     @Enumerated(EnumType.STRING)
-    val sex: Item.Sex,
+    val sex: Item.Sex? = null,
     val rating: Long? = 0L,
 
     val oldPrice: Long,
+    var newPrice: Long,
     var sale: Long? = 0L,
 
     @OneToMany(
@@ -26,7 +27,7 @@ class ItemEntity(
         orphanRemoval = true
     )
     val options: MutableList<OptionEntity>? = mutableListOf(),
-    
+
     @Enumerated(EnumType.STRING)
     val category: Item.Category,
     @Enumerated(EnumType.STRING)
@@ -39,8 +40,7 @@ class ItemEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L
-    
-    var newPrice: Long = (oldPrice * (1- sale!!) + 5) / 10 * 10
-    val nextItemId: Long = id + 10
 
+    val nextItemId: Long = id + 10
+    
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
@@ -1,0 +1,41 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import javax.persistence.*
+
+@Entity
+@Table(name = "items")
+class ItemEntity(
+    val name: String,
+    val brand: String,
+    val imageUrl: String,
+
+    @Enumerated(EnumType.STRING)
+    val label: Item.Label? = null,
+    @Enumerated(EnumType.STRING)
+    val sex: Item.Sex,
+    val rating: Long? = 0L,
+
+    val oldPrice: Long,
+    var sale: Long? = 0L,
+
+    @ElementCollection(fetch=FetchType.LAZY) 
+    val options: List<String>,
+    
+    @Enumerated(EnumType.STRING)
+    val category: Item.Category,
+    @Enumerated(EnumType.STRING)
+    val subCategory: Item.SubCategory,
+
+    //"reviews": Review[],    # 구매후기
+    
+) {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+    
+    var newPrice: Long = (oldPrice * (1- sale!!) + 5) / 10 * 10
+    val nextItemId: Long = id + 10
+
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
@@ -20,6 +20,7 @@ class ItemEntity(
     var sale: Long? = 0L,
 
     @ElementCollection(fetch=FetchType.LAZY) 
+    @Column(name="OptionsName")
     val options: List<String>,
     
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Component
+
+interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositoryCustom {
+    fun findAllByCategoryOrderByRatingDesc(category: Item.Category): List<ItemEntity>
+    fun findAllByOrderByRatingDesc(): List<ItemEntity>
+}
+
+interface ItemRepositoryCustom
+
+@Component
+class ItemRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : ItemRepositoryCustom

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/MemoryDB.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/MemoryDB.kt
@@ -1,14 +1,17 @@
 package com.wafflestudio.toyproject.team4.core.item.database
 
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.jsoup.nodes.Node
 import org.springframework.boot.context.event.ApplicationStartedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
-class MemoryDB {
+class MemoryDB (
+    private val itemRepository: ItemRepository
+) {
     /**
      * 서버가 시작하면, 크롤링을 통해 무신사에서 실시간 랭킹 긁어와서 아이템 repository에 저장
      * 각 대분류 - 소분류별로 5개씩
@@ -26,41 +29,37 @@ class MemoryDB {
          * SHOES : 005       - GOODOO(005014), SANDAL(005004), SLIPPER(005018) // SNEAKERS(mainCategory = 18)
          * HEADWEAR : 007    - CAP(007001), HAT(007004), BEANIE(007005)
          **/
-        
+
         crawling("001", "001006")
     }
-    
-    
-    private fun crawling(mainCategoryId: String, subCategoryId: String){
+
+
+    @Transactional
+    fun crawling(mainCategoryId: String, subCategoryId: String) {
         val url: String = "https://www.musinsa.com/ranking/best?period=now" +
-                           "&mainCategory=$mainCategoryId&subCategory=$subCategoryId"
+            "&mainCategory=$mainCategoryId&subCategory=$subCategoryId"
         val document: Document = Jsoup.connect(url).get()
-        val itemInfoList: List<List<Node>> = document
-            .select("div[class=list-box box]")
-            .select("ul li[class=li_box]")
-            .subList(0, 5) // 각 대분류-소분류별로 5개씩 값 긁어오기
-            .map {
-                it.childNodes().filterIndexed { idx,_ -> idx%2!=0 }
+
+        document.run {
+            val labelInfoList = this.getElementsByClass("box-icon-right").map { it.text() }
+            val imageInfoList = this.getElementsByClass("lazyload lazy").map { it.attr("data-original") }
+            val brandInfoList = this.select("div p[class=item_title] a").map { it.text() }
+            val itemNameList = this.select("div p[class=list_info] a").map { it.attr("title") }
+            val priceInfoList = this.select("div p[class=price]").map { it.text() }
+
+            for (idx in 0..4) {
+                val newItem = ItemEntity(
+                    name = itemNameList[idx],
+                    brand = brandInfoList[idx],
+                    imageUrl = imageInfoList[idx],
+                    //label = labelInfoList[idx],
+                    oldPrice = priceInfoList[idx].substringBefore(" ").dropLast(1).replace(",", "").toLong(),
+                    newPrice = priceInfoList[idx].substringAfter(" ").dropLast(1).replace(",", "").toLong(),
+                    category = Item.Category.TOP,
+                    subCategory = Item.SubCategory.SWEATER
+                )
+                itemRepository.save(newItem)
             }
-
-        return itemInfoList.forEach { itemInfo -> parseItemInfo(itemInfo) }
+        }
     }
-    
-    private fun parseItemInfo(itemInfo: List<Node>) {
-        // 라벨
-        val label = itemInfo[1].childNode(1).childNode(0)
-        // 브랜드
-        
-        // 품목명
-        // 브랜드
-        // 이미지 url
-        // 라벨
-        // 기존가
-        // 신규가
-        // 할인율
-        // 성별
-        // 별점
-        
-    }
-
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/MemoryDB.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/MemoryDB.kt
@@ -1,0 +1,66 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Node
+import org.springframework.boot.context.event.ApplicationStartedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class MemoryDB {
+    /**
+     * 서버가 시작하면, 크롤링을 통해 무신사에서 실시간 랭킹 긁어와서 아이템 repository에 저장
+     * 각 대분류 - 소분류별로 5개씩
+     */
+
+    @EventListener
+    fun makeMockData(event: ApplicationStartedEvent) {
+
+        /** mainCategory - subCategory
+         * TOP   : 001       - SWEATER(001006), HOODIE(001004), SWEATSHIRT(001005), SHIRT(001002)
+         * OUTER : 002       - COAT(002007), JACKET(002002), PADDING(002016), CARDIGAN(002020)
+         * PANTS : 003       - DENIM(003002), SLACKS(003008), JOGGER(003004), LEGGINGS(003005)
+         * SKIRT : 022       - MINISKIRT(022001), MEDISKIRT(022002), LONGSKIRT(022003)
+         * BAG   : 004       - BACKPACK(004001), CROSSBAG(004002), ECHOBAG(004014)
+         * SHOES : 005       - GOODOO(005014), SANDAL(005004), SLIPPER(005018) // SNEAKERS(mainCategory = 18)
+         * HEADWEAR : 007    - CAP(007001), HAT(007004), BEANIE(007005)
+         **/
+        
+        crawling("001", "001006")
+    }
+    
+    
+    private fun crawling(mainCategoryId: String, subCategoryId: String){
+        val url: String = "https://www.musinsa.com/ranking/best?period=now" +
+                           "&mainCategory=$mainCategoryId&subCategory=$subCategoryId"
+        val document: Document = Jsoup.connect(url).get()
+        val itemInfoList: List<List<Node>> = document
+            .select("div[class=list-box box]")
+            .select("ul li[class=li_box]")
+            .subList(0, 5) // 각 대분류-소분류별로 5개씩 값 긁어오기
+            .map {
+                it.childNodes().filterIndexed { idx,_ -> idx%2!=0 }
+            }
+
+        return itemInfoList.forEach { itemInfo -> parseItemInfo(itemInfo) }
+    }
+    
+    private fun parseItemInfo(itemInfo: List<Node>) {
+        // 라벨
+        val label = itemInfo[1].childNode(1).childNode(0)
+        // 브랜드
+        
+        // 품목명
+        // 브랜드
+        // 이미지 url
+        // 라벨
+        // 기존가
+        // 신규가
+        // 할인율
+        // 성별
+        // 별점
+        
+    }
+
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionEntity.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import javax.persistence.*
+
+@Entity
+@Table(name = "options")
+class OptionEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "itemId")
+    val item: ItemEntity,
+    
+    val optionName: String
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionRepository.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface OptionRepository : JpaRepository<OptionEntity, Long>

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
@@ -1,0 +1,53 @@
+package com.wafflestudio.toyproject.team4.core.item.domain
+
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
+
+data class Item (
+    val id: Long,
+    val name: String,
+    val brand: String,
+    val imageUrl: String,
+    val label: String,
+    val oldPrice: Long,
+    val newPrice: Long,
+    val sale: Long,
+) {
+    
+    enum class Label {
+        LIMITED, BOUTIQUE, PREORDER, EXCLUSIVE
+    }
+    
+    enum class Sex {
+        MALE, FEMALE, UNISEX
+    }
+    
+    enum class Category {
+        TOP, OUTER, PANTS, SKIRT, BAG, SHOES, HEADWEAR
+    }
+
+    enum class SubCategory {
+        SWEATER, HOODIE, SWEATSHIRT, SHIRT,  // TOP
+        COAT, JACKET, PADDING, CARDIGAN,     // OUTER
+        DENIM, SLACKS, JOGGER, LEGGINGS,     // PANTS
+        MINISKIRT, MEDISKIRT, LONGSKIRT,     // SKIRT
+        BACKPACK, CROSSBAG, ECHOBAG,         // BAG
+        GOODOO, SANDAL, SLIPPER, SNEAKERS,   // SHOES
+        CAP, HAT, BEANIE                     // HEADWEAR 
+    }
+    
+    
+    companion object {
+        fun of(entity: ItemEntity): Item = entity.run {
+            Item(
+                id = id,
+                name = name,
+                brand = brand,
+                imageUrl = imageUrl,
+                label = label.toString(),
+                oldPrice = oldPrice,
+                newPrice = newPrice,
+                sale = sale!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
@@ -7,7 +7,7 @@ data class Item (
     val name: String,
     val brand: String,
     val imageUrl: String,
-    val label: String,
+    val label: String?,
     val oldPrice: Long,
     val newPrice: Long,
     val sale: Long,

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -25,10 +25,10 @@ class ItemServiceImpl(
     override fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse {
         val category = itemRequest.category
         val rankingList = with(itemRepository) {
-            if (category == null) this.findAllByOrderByRatingDesc()
+            if (category.isNullOrEmpty()) this.findAllByOrderByRatingDesc()
             else this.findAllByCategoryOrderByRatingDesc(Item.Category.valueOf(category))
         }
-        val nextItemId = rankingList[0].nextItemId
+        val nextItemId = rankingList.firstOrNull()?.nextItemId
         
         return ItemRankingResponse(
             items = rankingList.map { entity -> Item.of(entity) },

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -1,15 +1,19 @@
 package com.wafflestudio.toyproject.team4.core.item.service
 
+import com.wafflestudio.toyproject.team4.common.CustomHttp404
 import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
 import com.wafflestudio.toyproject.team4.core.item.api.response.ItemRankingResponse
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
 import com.wafflestudio.toyproject.team4.core.item.database.ItemRepository
 import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 
 interface ItemService {
     fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse
+    fun getItem(itemId: Long): ItemEntity
 }
 
 @Service
@@ -30,5 +34,10 @@ class ItemServiceImpl(
             items = rankingList.map { entity -> Item.of(entity) },
             nextItemId = nextItemId
         )
+    }
+
+    override fun getItem(itemId: Long): ItemEntity {
+        return itemRepository.findByIdOrNull(itemId)
+            ?: throw CustomHttp404("존재하지 않는 상품 아이디입니다.")
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -1,0 +1,34 @@
+package com.wafflestudio.toyproject.team4.core.item.service
+
+import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
+import com.wafflestudio.toyproject.team4.core.item.api.response.ItemRankingResponse
+import com.wafflestudio.toyproject.team4.core.item.database.ItemRepository
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+
+interface ItemService {
+    fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse
+}
+
+@Service
+class ItemServiceImpl(
+    private val itemRepository: ItemRepository,
+) : ItemService {
+
+    @Transactional(readOnly = true)
+    override fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse {
+        val category = itemRequest.category
+        val rankingList = with(itemRepository) {
+            if (category == null) this.findAllByOrderByRatingDesc()
+            else this.findAllByCategoryOrderByRatingDesc(Item.Category.valueOf(category))
+        }
+        val nextItemId = rankingList[0].nextItemId
+        
+        return ItemRankingResponse(
+            items = rankingList.map { entity -> Item.of(entity) },
+            nextItemId = nextItemId
+        )
+    }
+}


### PR DESCRIPTION
6일 회의에서 잠깐 말씀드렸던 mock data 생성을 위한 클래스입니다.
실제 무신사에서 크롤링을 통해 각 대분류-소분류별 실시간 랭킹에서 상위 5개 상품들의 정보를 긁어오는 형태로 작성중이에요 !


아직 완성된 것은 아니지만,
이렇게 생성하려고 한다 정도 공유드리면 좋을 거 같아서 PR 올려둡니다 !

---
(0107 추가)
![image](https://user-images.githubusercontent.com/90292371/211138851-e37956b7-39a6-476d-acdd-bf6d9e6e79dc.png)

상의 - 니트/스웨터 품목에 대해서 한번 시행해봤는데 (enum field에 대한 건 아직 처리를 못하긴 했지만.. 그래도 전반적으로) DB에 잘 저장되는 거 같네요 !
현 코드 토대로 디벨롭 해서 저희가 살펴보는 모든 분류에 대해서 상품 정보 끌어와서, itemRepository에 저장되도록 해보겠습니다!


