### PR TITLE
Add api/user/me

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -1,0 +1,24 @@
+package com.wafflestudio.toyproject.team4.core.item.api
+
+import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
+import com.wafflestudio.toyproject.team4.core.item.service.ItemService
+import org.springframework.web.bind.annotation.*
+
+
+@RestController
+@RequestMapping("/api")
+class ItemController(
+    private val itemService: ItemService
+) {
+    
+    @GetMapping("/items")
+    fun getHomepage(
+        @RequestBody itemRequest: ItemRequest
+    ) = itemService.getItemRankingList(itemRequest)
+    
+    @GetMapping("/item/{id}")
+    fun getItem(
+        @PathVariable(value="id") itemId: Long
+    ) = itemService.getItem(itemId)
+
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/request/ItemRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/request/ItemRequest.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.toyproject.team4.core.item.api.request
+
+data class ItemRequest(
+    val category: String? = null,
+    val nextItemId: Long? = null
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.toyproject.team4.core.item.api.response
+
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+
+data class ItemRankingResponse (
+    val items: List<Item>,
+    val nextItemId: Long?
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemEntity.kt
@@ -1,0 +1,46 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import javax.persistence.*
+
+@Entity
+@Table(name = "items")
+class ItemEntity(
+    val name: String,
+    val brand: String,
+    val imageUrl: String,
+
+    @Enumerated(EnumType.STRING)
+    val label: Item.Label? = null,
+    @Enumerated(EnumType.STRING)
+    val sex: Item.Sex,
+    val rating: Long? = 0L,
+
+    val oldPrice: Long,
+    var sale: Long? = 0L,
+
+    @OneToMany(
+        mappedBy = "item",
+        fetch = FetchType.LAZY,
+        cascade = [CascadeType.ALL],
+        orphanRemoval = true
+    )
+    val options: MutableList<OptionEntity>? = mutableListOf(),
+    
+    @Enumerated(EnumType.STRING)
+    val category: Item.Category,
+    @Enumerated(EnumType.STRING)
+    val subCategory: Item.SubCategory,
+
+    //"reviews": Review[],    # 구매후기
+    
+) {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+    
+    var newPrice: Long = (oldPrice * (1- sale!!) + 5) / 10 * 10
+    val nextItemId: Long = id + 10
+
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
@@ -10,9 +10,19 @@ interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositoryCustom
     fun findAllByOrderByRatingDesc(): List<ItemEntity>
 }
 
-interface ItemRepositoryCustom
+interface ItemRepositoryCustom {
+    fun getItems(itemEntities: MutableList<ItemEntity>): MutableList<Item>
+}
 
 @Component
 class ItemRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory
-) : ItemRepositoryCustom
+) : ItemRepositoryCustom {
+    override fun getItems(itemEntities: MutableList<ItemEntity>): MutableList<Item> {
+        val result = mutableListOf<Item>()
+        for (itemEntity in itemEntities) {
+            result.add(Item.of(itemEntity))
+        }
+        return result
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Component
+
+interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositoryCustom {
+    fun findAllByCategoryOrderByRatingDesc(category: Item.Category): List<ItemEntity>
+    fun findAllByOrderByRatingDesc(): List<ItemEntity>
+}
+
+interface ItemRepositoryCustom
+
+@Component
+class ItemRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : ItemRepositoryCustom

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionEntity.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import javax.persistence.*
+
+@Entity
+@Table(name = "options")
+class OptionEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "itemId")
+    val item: ItemEntity,
+    
+    val optionName: String
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/OptionRepository.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.toyproject.team4.core.item.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface OptionRepository : JpaRepository<OptionEntity, Long>

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
@@ -1,0 +1,53 @@
+package com.wafflestudio.toyproject.team4.core.item.domain
+
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
+
+data class Item (
+    val id: Long,
+    val name: String,
+    val brand: String,
+    val imageUrl: String,
+    val label: String?,
+    val oldPrice: Long,
+    val newPrice: Long,
+    val sale: Long,
+) {
+    
+    enum class Label {
+        LIMITED, BOUTIQUE, PREORDER, EXCLUSIVE
+    }
+    
+    enum class Sex {
+        MALE, FEMALE, UNISEX
+    }
+    
+    enum class Category {
+        TOP, OUTER, PANTS, SKIRT, BAG, SHOES, HEADWEAR
+    }
+
+    enum class SubCategory {
+        SWEATER, HOODIE, SWEATSHIRT, SHIRT,  // TOP
+        COAT, JACKET, PADDING, CARDIGAN,     // OUTER
+        DENIM, SLACKS, JOGGER, LEGGINGS,     // PANTS
+        MINISKIRT, MEDISKIRT, LONGSKIRT,     // SKIRT
+        BACKPACK, CROSSBAG, ECHOBAG,         // BAG
+        GOODOO, SANDAL, SLIPPER, SNEAKERS,   // SHOES
+        CAP, HAT, BEANIE                     // HEADWEAR 
+    }
+    
+    
+    companion object {
+        fun of(entity: ItemEntity): Item = entity.run {
+            Item(
+                id = id,
+                name = name,
+                brand = brand,
+                imageUrl = imageUrl,
+                label = label.toString(),
+                oldPrice = oldPrice,
+                newPrice = newPrice,
+                sale = sale!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -1,0 +1,43 @@
+package com.wafflestudio.toyproject.team4.core.item.service
+
+import com.wafflestudio.toyproject.team4.common.CustomHttp404
+import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
+import com.wafflestudio.toyproject.team4.core.item.api.response.ItemRankingResponse
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
+import com.wafflestudio.toyproject.team4.core.item.database.ItemRepository
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+
+interface ItemService {
+    fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse
+    fun getItem(itemId: Long): ItemEntity
+}
+
+@Service
+class ItemServiceImpl(
+    private val itemRepository: ItemRepository,
+) : ItemService {
+
+    @Transactional(readOnly = true)
+    override fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse {
+        val category = itemRequest.category
+        val rankingList = with(itemRepository) {
+            if (category.isNullOrEmpty()) this.findAllByOrderByRatingDesc()
+            else this.findAllByCategoryOrderByRatingDesc(Item.Category.valueOf(category))
+        }
+        val nextItemId = rankingList.firstOrNull()?.nextItemId
+        
+        return ItemRankingResponse(
+            items = rankingList.map { entity -> Item.of(entity) },
+            nextItemId = nextItemId
+        )
+    }
+
+    override fun getItem(itemId: Long): ItemEntity {
+        return itemRepository.findByIdOrNull(itemId)
+            ?: throw CustomHttp404("존재하지 않는 상품 아이디입니다.")
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
@@ -1,0 +1,52 @@
+package com.wafflestudio.toyproject.team4.core.user.api
+
+
+import com.wafflestudio.toyproject.team4.common.Authenticated
+import com.wafflestudio.toyproject.team4.common.UserContext
+import com.wafflestudio.toyproject.team4.core.user.service.UserService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+
+@RestController
+@RequestMapping("/api/user")
+class UserController(
+    private val userService: UserService
+) {
+
+//    @Authenticated
+//    @GetMapping("/me")
+//    fun getMe(
+//        @RequestHeader(value = "Authorization") authorization: String,
+//        @UserContext username: String,
+//        ) = ResponseEntity(userService.getMe(username), HttpStatus.OK)
+
+    @Authenticated
+    @GetMapping("/me/reviews")
+    fun getReviews(
+        @RequestHeader(value = "Authorization") authorization: String,
+        @UserContext username: String,
+    ) = ResponseEntity(userService.getReviews(username), HttpStatus.OK)
+
+//    @Authenticated
+//    @GetMapping("/me/purchases")
+//    fun getPurchases(
+//        @RequestHeader(value = "Authorization") authorization: String,
+//        @UserContext username: String,
+//    ) = ResponseEntity(userService.getPurchases(username), HttpStatus.OK)
+//    
+//    @Authenticated
+//    @GetMapping("/me/shopping-cart")
+//    fun getShoppingCart(
+//        @RequestHeader(value = "Authorization") authorization: String,
+//        @UserContext username: String,
+//    ) = ResponseEntity(userService.getShoppingCart(username), HttpStatus.OK)
+//    
+//    @Authenticated
+//    @GetMapping("/me/recently-viewed")
+//    fun getRecentlyViewed(
+//        @RequestHeader(value = "Authorization") authorization: String,
+//        @UserContext username: String,
+//    ) = ResponseEntity(userService.getRecentlyViewed(username), HttpStatus.OK)
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
@@ -42,11 +42,11 @@ class UserController(
         @RequestHeader(value = "Authorization") authorization: String,
         @UserContext username: String,
     ) = ResponseEntity(userService.getShoppingCart(username), HttpStatus.OK)
-//    
-//    @Authenticated
-//    @GetMapping("/me/recently-viewed")
-//    fun getRecentlyViewed(
-//        @RequestHeader(value = "Authorization") authorization: String,
-//        @UserContext username: String,
-//    ) = ResponseEntity(userService.getRecentlyViewed(username), HttpStatus.OK)
+
+    @Authenticated
+    @GetMapping("/me/recently-viewed")
+    fun getRecentlyViewed(
+        @RequestHeader(value = "Authorization") authorization: String,
+        @UserContext username: String,
+    ) = ResponseEntity(userService.getRecentlyViewed(username), HttpStatus.OK)
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
@@ -29,12 +29,12 @@ class UserController(
         @UserContext username: String,
     ) = ResponseEntity(userService.getReviews(username), HttpStatus.OK)
 
-//    @Authenticated
-//    @GetMapping("/me/purchases")
-//    fun getPurchases(
-//        @RequestHeader(value = "Authorization") authorization: String,
-//        @UserContext username: String,
-//    ) = ResponseEntity(userService.getPurchases(username), HttpStatus.OK)
+    @Authenticated
+    @GetMapping("/me/purchases")
+    fun getPurchases(
+        @RequestHeader(value = "Authorization") authorization: String,
+        @UserContext username: String,
+    ) = ResponseEntity(userService.getPurchases(username), HttpStatus.OK)
 //    
 //    @Authenticated
 //    @GetMapping("/me/shopping-cart")

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
@@ -15,12 +15,12 @@ class UserController(
     private val userService: UserService
 ) {
 
-//    @Authenticated
-//    @GetMapping("/me")
-//    fun getMe(
-//        @RequestHeader(value = "Authorization") authorization: String,
-//        @UserContext username: String,
-//        ) = ResponseEntity(userService.getMe(username), HttpStatus.OK)
+    @Authenticated
+    @GetMapping("/me")
+    fun getMe(
+        @RequestHeader(value = "Authorization") authorization: String,
+        @UserContext username: String,
+        ) = ResponseEntity(userService.getMe(username), HttpStatus.OK)
 
     @Authenticated
     @GetMapping("/me/reviews")

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
@@ -35,13 +35,13 @@ class UserController(
         @RequestHeader(value = "Authorization") authorization: String,
         @UserContext username: String,
     ) = ResponseEntity(userService.getPurchases(username), HttpStatus.OK)
-//    
-//    @Authenticated
-//    @GetMapping("/me/shopping-cart")
-//    fun getShoppingCart(
-//        @RequestHeader(value = "Authorization") authorization: String,
-//        @UserContext username: String,
-//    ) = ResponseEntity(userService.getShoppingCart(username), HttpStatus.OK)
+
+    @Authenticated
+    @GetMapping("/me/shopping-cart")
+    fun getShoppingCart(
+        @RequestHeader(value = "Authorization") authorization: String,
+        @UserContext username: String,
+    ) = ResponseEntity(userService.getShoppingCart(username), HttpStatus.OK)
 //    
 //    @Authenticated
 //    @GetMapping("/me/recently-viewed")

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/response/PurchaseResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/response/PurchaseResponse.kt
@@ -1,0 +1,30 @@
+package com.wafflestudio.toyproject.team4.core.user.api.response
+
+import com.wafflestudio.toyproject.team4.core.user.database.PurchaseEntity
+import java.time.LocalDateTime
+
+data class PurchaseResponse(
+    val brand: String,
+    val itemName: String,
+    val optionName: String?,
+    val imageUrl: String,
+
+    val id: Long,
+    val date: LocalDateTime,
+    val payment: Long,
+    val quantity: Long,
+) {
+    companion object {
+        fun of(purchaseEntity: PurchaseEntity) =
+            PurchaseResponse(
+                brand = purchaseEntity.itemEntity.brand,
+                itemName = purchaseEntity.itemEntity.name,
+                optionName = purchaseEntity.optionName,
+                imageUrl = purchaseEntity.itemEntity.imageUrl,
+                id = purchaseEntity.id,
+                date = purchaseEntity.date,
+                payment = purchaseEntity.payment,
+                quantity = purchaseEntity.quantity
+            )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/response/ReviewResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/response/ReviewResponse.kt
@@ -1,0 +1,42 @@
+package com.wafflestudio.toyproject.team4.core.user.api.response
+
+import com.wafflestudio.toyproject.team4.core.user.database.Color
+import com.wafflestudio.toyproject.team4.core.user.database.ReviewEntity
+import com.wafflestudio.toyproject.team4.core.user.database.Size
+import com.wafflestudio.toyproject.team4.core.user.domain.Comment
+import com.wafflestudio.toyproject.team4.core.user.domain.User
+
+data class ReviewResponse(
+    val nickname: String,
+    val sex: User.Sex?,
+    val height: Long?,
+    val weight: Long?,
+    
+    val itemName: String,
+    val optionName: String?,
+    val imageUrl: String,
+    
+    val rating: Long,
+    val text: String,
+    val size: Size,
+    val color: Color,
+) {
+    var comments: MutableList<Comment>? = null    
+    
+    companion object {
+        fun of(reviewEntity: ReviewEntity) =
+            ReviewResponse(
+                nickname = reviewEntity.userEntity.nickname,
+                sex = reviewEntity.userEntity.sex,
+                height = reviewEntity.userEntity.height,
+                weight = reviewEntity.userEntity.weight,
+                itemName = reviewEntity.itemEntity.name,
+                optionName = reviewEntity.purchaseEntity.optionName,
+                imageUrl = reviewEntity.itemEntity.imageUrl,
+                rating = reviewEntity.rating,
+                text = reviewEntity.text,
+                size = reviewEntity.size,
+                color = reviewEntity.color,
+            )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/response/UserResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/response/UserResponse.kt
@@ -1,0 +1,33 @@
+package com.wafflestudio.toyproject.team4.core.user.api.response
+
+import com.wafflestudio.toyproject.team4.core.user.database.UserEntity
+import com.wafflestudio.toyproject.team4.core.user.domain.User
+import java.time.LocalDateTime
+
+data class UserResponse(
+    val id: Long,
+    val username: String,
+    val nickname: String,
+    val imageUrl: String?,
+    val registrationDate: LocalDateTime,
+    val height: Long?,
+    val weight: Long?,
+    val sex: User.Sex?,
+
+) {    
+    var reviews: MutableList<ReviewResponse>? = null
+    
+    companion object {
+        fun of(userEntity: UserEntity) =
+            UserResponse(
+                id = userEntity.id,
+                username = userEntity.username,
+                nickname = userEntity.nickname,
+                imageUrl = userEntity.imageUrl,
+                registrationDate = userEntity.registrationDate,
+                height = userEntity.height,
+                weight = userEntity.weight,
+                sex = userEntity.sex,
+            )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/CommentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/CommentEntity.kt
@@ -1,0 +1,25 @@
+package com.wafflestudio.toyproject.team4.core.user.database
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import javax.persistence.*
+
+
+@Entity
+@Table(name = "comments")
+@EntityListeners(AuditingEntityListener::class)
+class CommentEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    val userEntity: UserEntity,
+    
+    var text: String,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    @CreatedDate
+    var date: LocalDateTime = LocalDateTime.now()
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/CommentRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/CommentRepository.kt
@@ -1,0 +1,27 @@
+package com.wafflestudio.toyproject.team4.core.user.database
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.toyproject.team4.core.user.domain.Comment
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Component
+
+interface CommentRepository : JpaRepository<CommentEntity, Long>, CommentRepositoryCustom {
+}
+
+interface CommentRepositoryCustom {
+    fun getCommentResponses(commentEntities: MutableList<CommentEntity>): MutableList<Comment>
+}
+
+@Component
+class CommentRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : CommentRepositoryCustom {
+
+    override fun getCommentResponses(commentEntities: MutableList<CommentEntity>): MutableList<Comment> {
+        var result = mutableListOf<Comment>()
+        for (commentEntity in commentEntities) {
+            result.add(Comment.of(commentEntity))
+        }
+        return result
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/PurchaseEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/PurchaseEntity.kt
@@ -1,0 +1,33 @@
+package com.wafflestudio.toyproject.team4.core.user.database
+
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
+import com.wafflestudio.toyproject.team4.core.user.domain.User
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import javax.persistence.*
+
+
+@Entity
+@Table(name = "purchases")
+@EntityListeners(AuditingEntityListener::class)
+class PurchaseEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    val userEntity: UserEntity,
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "itemId")
+    val itemEntity: ItemEntity,
+    
+    val optionName: String,
+    val payment: Long,
+    val quantity: Long,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    @CreatedDate
+    var date: LocalDateTime = LocalDateTime.now()
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/PurchaseRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/PurchaseRepository.kt
@@ -1,0 +1,27 @@
+package com.wafflestudio.toyproject.team4.core.user.database
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.toyproject.team4.core.user.api.response.PurchaseResponse
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Component
+
+interface PurchaseRepository : JpaRepository<PurchaseEntity, Long>, PurchaseRepositoryCustom {
+}
+
+interface PurchaseRepositoryCustom {
+    fun getPurchaseResponses(purchaseEntities: MutableList<PurchaseEntity>): MutableList<PurchaseResponse>
+}
+
+@Component
+class PurchaseRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : PurchaseRepositoryCustom {
+
+    override fun getPurchaseResponses(purchaseEntities: MutableList<PurchaseEntity>): MutableList<PurchaseResponse> {
+        val result = mutableListOf<PurchaseResponse>()
+        for (purchaseEntity in purchaseEntities) {
+            result.add(PurchaseResponse.of(purchaseEntity))
+        }
+        return result
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/ReviewEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/ReviewEntity.kt
@@ -1,0 +1,41 @@
+package com.wafflestudio.toyproject.team4.core.user.database
+
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import javax.persistence.*
+
+
+@Entity
+@Table(name = "reviews")
+@EntityListeners(AuditingEntityListener::class)
+class ReviewEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    val userEntity: UserEntity,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "itemId")
+    val itemEntity: ItemEntity,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "purchaseId")
+    val purchaseEntity: PurchaseEntity,
+    
+    var rating: Long,
+    var text: String,
+    val size: Size,
+    val color: Color,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+    
+    @OneToMany(cascade = [CascadeType.REMOVE])
+    var commentEntities: MutableList<CommentEntity> = mutableListOf()
+}
+
+enum class Size {
+    BIG, NORMAL, SMALL,
+}
+
+enum class Color {
+    BRIGHT, NORMAL, BLURRY,
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/ReviewRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/ReviewRepository.kt
@@ -1,0 +1,30 @@
+package com.wafflestudio.toyproject.team4.core.user.database
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.toyproject.team4.core.user.api.response.ReviewResponse
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Component
+
+interface ReviewRepository : JpaRepository<ReviewEntity, Long>, ReviewRepositoryCustom {
+}
+
+interface ReviewRepositoryCustom {
+    fun getReviewResponses(reviewEntities: MutableList<ReviewEntity>): MutableList<ReviewResponse>
+}
+
+@Component
+class ReviewRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory,
+    private val commentRepository: CommentRepository,
+) : ReviewRepositoryCustom {
+
+    override fun getReviewResponses(reviewEntities: MutableList<ReviewEntity>): MutableList<ReviewResponse> {
+        val result = mutableListOf<ReviewResponse>()
+        for (reviewEntity in reviewEntities) {
+            val reviewResponse = ReviewResponse.of(reviewEntity)
+            reviewResponse.comments = commentRepository.getCommentResponses(reviewEntity.commentEntities)
+            result.add(reviewResponse)
+        }
+        return result
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserEntity.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.toyproject.team4.core.user.database
 
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
 import com.wafflestudio.toyproject.team4.core.user.domain.User
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
@@ -26,7 +27,10 @@ class UserEntity(
     var weight: Long? = null,
     var socialKey: String? = null,
 
-    var refreshToken: String? = null
+    var refreshToken: String? = null,
+
+    var shoppingCart: MutableList<ItemEntity> = mutableListOf(),
+    var recentlyViewed: MutableList<ItemEntity> = mutableListOf(),
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,4 +38,10 @@ class UserEntity(
 
     @CreatedDate
     var registrationDate: LocalDateTime = LocalDateTime.now()
+    
+    @OneToMany(mappedBy = "userEntity", cascade = [CascadeType.REMOVE])
+    var reviewEntities: MutableList<ReviewEntity> = mutableListOf()
+    
+    @OneToMany(mappedBy = "userEntity", cascade = [CascadeType.REMOVE])
+    var purchaseEntities: MutableList<PurchaseEntity> = mutableListOf()
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/domain/Comment.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/domain/Comment.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.toyproject.team4.core.user.domain
+
+import com.wafflestudio.toyproject.team4.core.user.database.CommentEntity
+import java.time.LocalDateTime
+
+data class Comment(
+    val id: Long,
+    val username: String,
+    val text: String,
+    val date: LocalDateTime,
+) {
+    companion object {
+        fun of(commentEntity: CommentEntity) =
+            Comment(
+                id = commentEntity.id,
+                username = commentEntity.userEntity.username,
+                text = commentEntity.text,
+                date = commentEntity.date,
+            )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/UserService.kt
@@ -17,7 +17,7 @@ interface UserService {
     fun getReviews(username: String): MutableList<ReviewResponse>
     fun getPurchases(username: String): MutableList<PurchaseResponse>
     fun getShoppingCart(username: String): MutableList<Item>
-//    fun getRecentlyViewed(username: String): MutableList<Item>
+    fun getRecentlyViewed(username: String): MutableList<Item>
 }
 
 @Service
@@ -57,11 +57,11 @@ class UserServiceImpl(
             ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
         return itemRepository.getItems(userEntity.shoppingCart)
     }
-//
-//    @Transactional
-//    override fun getRecentlyViewed(username: String): MutableList<Item> {
-//        val userEntity = userRepository.findByUsername(username)
-//            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
-//        return itemRepository.getItems(userEntity.recentlyViewed)
-//    }
+
+    @Transactional
+    override fun getRecentlyViewed(username: String): MutableList<Item> {
+        val userEntity = userRepository.findByUsername(username)
+            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
+        return itemRepository.getItems(userEntity.recentlyViewed)
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/UserService.kt
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service
 import javax.transaction.Transactional
 
 interface UserService {
-//    fun getMe(username: String): UserResponse
+    fun getMe(username: String): UserResponse
     fun getReviews(username: String): MutableList<ReviewResponse>
 //    fun getPurchases(username: String): MutableList<PurchaseResponse>
 //    fun getShoppingCart(username: String): MutableList<Item>
@@ -28,14 +28,14 @@ class UserServiceImpl(
 //    private val itemRepository: ItemRepository,
 ) : UserService {
 
-//    @Transactional
-//    override fun getMe(username: String): UserResponse {
-//        val userEntity = userRepository.findByUsername(username)
-//            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
-//        val userResponse = UserResponse.of(userEntity)
-//        userResponse.reviews = reviewRepository.getReviewResponses(userEntity.reviewEntities)
-//        return userResponse
-//    }
+    @Transactional
+    override fun getMe(username: String): UserResponse {
+        val userEntity = userRepository.findByUsername(username)
+            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
+        val userResponse = UserResponse.of(userEntity)
+        userResponse.reviews = reviewRepository.getReviewResponses(userEntity.reviewEntities)
+        return userResponse
+    }
 
     @Transactional
     override fun getReviews(username: String): MutableList<ReviewResponse> {

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/UserService.kt
@@ -16,7 +16,7 @@ interface UserService {
     fun getMe(username: String): UserResponse
     fun getReviews(username: String): MutableList<ReviewResponse>
     fun getPurchases(username: String): MutableList<PurchaseResponse>
-//    fun getShoppingCart(username: String): MutableList<Item>
+    fun getShoppingCart(username: String): MutableList<Item>
 //    fun getRecentlyViewed(username: String): MutableList<Item>
 }
 
@@ -25,7 +25,7 @@ class UserServiceImpl(
     private val userRepository: UserRepository,
     private val reviewRepository: ReviewRepository,
     private val purchaseRepository: PurchaseRepository,
-//    private val itemRepository: ItemRepository,
+    private val itemRepository: ItemRepository,
 ) : UserService {
 
     @Transactional
@@ -50,13 +50,13 @@ class UserServiceImpl(
             ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
         return purchaseRepository.getPurchaseResponses(userEntity.purchaseEntities)
     }
-//
-//    @Transactional
-//    override fun getShoppingCart(username: String): MutableList<Item> {
-//        val userEntity = userRepository.findByUsername(username)
-//            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
-//        return itemRepository.getItems(userEntity.shoppingCart)
-//    }
+
+    @Transactional
+    override fun getShoppingCart(username: String): MutableList<Item> {
+        val userEntity = userRepository.findByUsername(username)
+            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
+        return itemRepository.getItems(userEntity.shoppingCart)
+    }
 //
 //    @Transactional
 //    override fun getRecentlyViewed(username: String): MutableList<Item> {

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/UserService.kt
@@ -1,0 +1,67 @@
+package com.wafflestudio.toyproject.team4.core.user.service
+
+import com.wafflestudio.toyproject.team4.common.CustomHttp404
+import com.wafflestudio.toyproject.team4.core.item.database.ItemRepository
+import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import com.wafflestudio.toyproject.team4.core.user.api.response.PurchaseResponse
+import com.wafflestudio.toyproject.team4.core.user.api.response.ReviewResponse
+import com.wafflestudio.toyproject.team4.core.user.api.response.UserResponse
+import com.wafflestudio.toyproject.team4.core.user.database.PurchaseRepository
+import com.wafflestudio.toyproject.team4.core.user.database.ReviewRepository
+import com.wafflestudio.toyproject.team4.core.user.database.UserRepository
+import org.springframework.stereotype.Service
+import javax.transaction.Transactional
+
+interface UserService {
+//    fun getMe(username: String): UserResponse
+    fun getReviews(username: String): MutableList<ReviewResponse>
+//    fun getPurchases(username: String): MutableList<PurchaseResponse>
+//    fun getShoppingCart(username: String): MutableList<Item>
+//    fun getRecentlyViewed(username: String): MutableList<Item>
+}
+
+@Service
+class UserServiceImpl(
+    private val userRepository: UserRepository,
+    private val reviewRepository: ReviewRepository,
+//    private val purchaseRepository: PurchaseRepository,
+//    private val itemRepository: ItemRepository,
+) : UserService {
+
+//    @Transactional
+//    override fun getMe(username: String): UserResponse {
+//        val userEntity = userRepository.findByUsername(username)
+//            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
+//        val userResponse = UserResponse.of(userEntity)
+//        userResponse.reviews = reviewRepository.getReviewResponses(userEntity.reviewEntities)
+//        return userResponse
+//    }
+
+    @Transactional
+    override fun getReviews(username: String): MutableList<ReviewResponse> {
+        val userEntity = userRepository.findByUsername(username)
+            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
+        return reviewRepository.getReviewResponses(userEntity.reviewEntities)
+    }
+
+//    @Transactional
+//    override fun getPurchases(username: String): MutableList<PurchaseResponse> {
+//        val userEntity = userRepository.findByUsername(username)
+//            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
+//        return purchaseRepository.getPurchaseResponses(userEntity.purchaseEntities)
+//    }
+//
+//    @Transactional
+//    override fun getShoppingCart(username: String): MutableList<Item> {
+//        val userEntity = userRepository.findByUsername(username)
+//            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
+//        return itemRepository.getItems(userEntity.shoppingCart)
+//    }
+//
+//    @Transactional
+//    override fun getRecentlyViewed(username: String): MutableList<Item> {
+//        val userEntity = userRepository.findByUsername(username)
+//            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
+//        return itemRepository.getItems(userEntity.recentlyViewed)
+//    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/UserService.kt
@@ -15,7 +15,7 @@ import javax.transaction.Transactional
 interface UserService {
     fun getMe(username: String): UserResponse
     fun getReviews(username: String): MutableList<ReviewResponse>
-//    fun getPurchases(username: String): MutableList<PurchaseResponse>
+    fun getPurchases(username: String): MutableList<PurchaseResponse>
 //    fun getShoppingCart(username: String): MutableList<Item>
 //    fun getRecentlyViewed(username: String): MutableList<Item>
 }
@@ -24,7 +24,7 @@ interface UserService {
 class UserServiceImpl(
     private val userRepository: UserRepository,
     private val reviewRepository: ReviewRepository,
-//    private val purchaseRepository: PurchaseRepository,
+    private val purchaseRepository: PurchaseRepository,
 //    private val itemRepository: ItemRepository,
 ) : UserService {
 
@@ -44,12 +44,12 @@ class UserServiceImpl(
         return reviewRepository.getReviewResponses(userEntity.reviewEntities)
     }
 
-//    @Transactional
-//    override fun getPurchases(username: String): MutableList<PurchaseResponse> {
-//        val userEntity = userRepository.findByUsername(username)
-//            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
-//        return purchaseRepository.getPurchaseResponses(userEntity.purchaseEntities)
-//    }
+    @Transactional
+    override fun getPurchases(username: String): MutableList<PurchaseResponse> {
+        val userEntity = userRepository.findByUsername(username)
+            ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
+        return purchaseRepository.getPurchaseResponses(userEntity.purchaseEntities)
+    }
 //
 //    @Transactional
 //    override fun getShoppingCart(username: String): MutableList<Item> {


### PR DESCRIPTION
/api/user/me
/api/user/me/reviews
/api/user/me/purchases
/api/user/me/shopping-cart
/api/user/me/recently-viewed
이렇게 위 5가지 API를 구현하였습니다.
(아직 Front에서 model 구성을 하지 않은 /api/user/me/item-inquiry와 /api/user/me/personal-inquiry 는 다음 스프린트 때 할 예정입니다.)

여기서 논의하고자 하는 내용이 2가지 있습니다.

1. domain과 response의 상충(?)
    우선 ReviewResponse와 PurchaseResponse는 둘 다 해당 data class의 속성들을 보면 알 수 있듯이 userEntity, itemEntity, reviewEntity 등등의 여러 entity에서 해당 api에서 필요한 속성들만을 뽑아서 client에게 전달해야 하므로 response를 따로 만들었습니다.
  그런데 UserResponse의 경우에는 위의 다른 예시와 같이 response 형태로 만들었지만 동주님께서 이미 domain에 만들어 놓으신 User와 거의 일치합니다. 이 경우에 domain의 User를 활용하고 UserResponse는 버려도 될지 잘 모르겠습니다....ㅠ

2. UserEntity의 두 array 속성(shoppingCart와 recentlyViewed)
    현재는 이 두 속성을 단순히 MutableList<ItemEntity>로 구현해 놓은 상황 입니다. 그러나 RDB에서 이들 array는 테이블에 저장하기 위해서는 일대다(One-To-Many) mapping을 해야 할 듯 합니다. 그런데 ItemEntity에 mapping을 할 경우에 itemEntity도 그 내부 속성에 무언가 추가를 해야 하는 지, 아니면 다른 어떤 방법이 있을 지 의견 구합니다..!