### PR TITLE
Fix /items, /item/:id

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -12,7 +12,7 @@ class ItemController(
 ) {
     
     @GetMapping("/items")
-    fun getHomepage(
+    fun getItemRankingList(
         @RequestBody itemRequest: ItemRequest
     ) = itemService.getItemRankingList(itemRequest)
     

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemResponse.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.toyproject.team4.core.item.api.response
+
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
+
+
+data class ItemResponse (
+    val item: ItemEntity
+) 

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/Item.kt
@@ -18,7 +18,7 @@ data class Item (
     }
     
     enum class Sex {
-        MALE, FEMALE, UNISEX
+        MALE, FEMALE, BOTH
     }
     
     enum class Category {

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -3,7 +3,7 @@ package com.wafflestudio.toyproject.team4.core.item.service
 import com.wafflestudio.toyproject.team4.common.CustomHttp404
 import com.wafflestudio.toyproject.team4.core.item.api.request.ItemRequest
 import com.wafflestudio.toyproject.team4.core.item.api.response.ItemRankingResponse
-import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
+import com.wafflestudio.toyproject.team4.core.item.api.response.ItemResponse
 import com.wafflestudio.toyproject.team4.core.item.database.ItemRepository
 import com.wafflestudio.toyproject.team4.core.item.domain.Item
 import org.springframework.data.repository.findByIdOrNull
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional
 
 interface ItemService {
     fun getItemRankingList(itemRequest: ItemRequest): ItemRankingResponse
-    fun getItem(itemId: Long): ItemEntity
+    fun getItem(itemId: Long): ItemResponse
 }
 
 @Service
@@ -28,7 +28,7 @@ class ItemServiceImpl(
             if (category.isNullOrEmpty()) this.findAllByOrderByRatingDesc()
             else this.findAllByCategoryOrderByRatingDesc(Item.Category.valueOf(category))
         }
-        val nextItemId = rankingList.firstOrNull()?.nextItemId
+        val nextItemId = rankingList.lastOrNull()?.nextItemId
         
         return ItemRankingResponse(
             items = rankingList.map { entity -> Item.of(entity) },
@@ -36,8 +36,9 @@ class ItemServiceImpl(
         )
     }
 
-    override fun getItem(itemId: Long): ItemEntity {
-        return itemRepository.findByIdOrNull(itemId)
+    override fun getItem(itemId: Long): ItemResponse {
+        val item = itemRepository.findByIdOrNull(itemId)
             ?: throw CustomHttp404("존재하지 않는 상품 아이디입니다.")
+        return ItemResponse(item)
     }
 }


### PR DESCRIPTION
(기존의 PR을 revert하려 했는데 안 되어서 새로 PR 올립니다.!)

동주님이 남겨주신 피드백 토대로
ItemController.kt 의 `getHomepage()` 함수명을 `getItemRankingList()`로 수정하였습니다.
현재 OptionEntity의 옵션명 필드가 `optionName`으로 되어 있는데, 혹 `option`이 더 낫다고 생각되시면 말씀해주세요. 오히려 옵션명이니 `name`도 괜찮을 것 같단 생각도 드네요.

그 외에 석찬님이 요청주신대로 GET /api/item/:id 의 response 값도 수정했습니다.
그리고 노션의 Rest API 문서에 item의 SEX 값이 { MALE, FEMALE, BOTH }로 되어 있어, 해당 부분도 수정하였습니다.