### PR TITLE
Add api/image-upload

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,9 @@ dependencies {
     implementation("com.querydsl:querydsl-core:$querydslVersion")
     kapt("com.querydsl:querydsl-apt:$querydslVersion:jpa")
     kapt(group = "com.querydsl", name = "querydsl-apt", classifier = "jpa")
+
+    // Cloudinary
+    implementation("com.cloudinary:cloudinary-http44:1.33.0")
 }
 
 // QueryDSL

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/common/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/common/CustomExceptionHandler.kt
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingRequestCookieException
 import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -38,5 +39,10 @@ class CustomExceptionHandler {
     @ExceptionHandler(value = [MissingRequestHeaderException::class])
     fun handle(e: MissingRequestHeaderException): ResponseEntity<Any> {
         return ResponseEntity("사용자 식별 불가: 접근할 수 없습니다.", HttpStatus.FORBIDDEN)
+    }
+
+    @ExceptionHandler(value = [MissingRequestCookieException::class])
+    fun handle(e: MissingRequestCookieException): ResponseEntity<Any> {
+        return ResponseEntity("쿠키에 토큰 갱신을 위한 정보가 없습니다.", HttpStatus.BAD_REQUEST)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/common/Exceptions.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/common/Exceptions.kt
@@ -13,3 +13,5 @@ class CustomHttp409(msg: String) : CustomHttpException(msg, HttpStatus.CONFLICT)
 class CustomHttp401(msg: String) : CustomHttpException(msg, HttpStatus.UNAUTHORIZED)
 
 class CustomHttp403(msg: String) : CustomHttpException(msg, HttpStatus.FORBIDDEN)
+
+class CustomHttp502(msg: String) : CustomHttpException(msg, HttpStatus.BAD_GATEWAY)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/image/CloudinaryProperties.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/image/CloudinaryProperties.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.toyproject.team4.core.image
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties("cloudinary")
+class CloudinaryProperties(
+    val apiEnvironment: String
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/image/api/ImageController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/image/api/ImageController.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.toyproject.team4.core.image.api
+
+import com.wafflestudio.toyproject.team4.core.image.service.ImageService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/image-upload")
+class ImageController(
+    private val imageService: ImageService
+) {
+    //    @Authenticated
+    @PostMapping
+    fun uploadImages(
+        @RequestPart images: List<MultipartFile>
+    ) = imageService.uploadImages(images)
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/image/api/response/ImageUploadResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/image/api/response/ImageUploadResponse.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.toyproject.team4.core.image.api.response
+
+data class ImageUploadResponse(
+    val secureImages: List<String>
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/image/service/ImageService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/image/service/ImageService.kt
@@ -1,0 +1,38 @@
+package com.wafflestudio.toyproject.team4.core.image.service
+
+import com.cloudinary.Cloudinary
+import com.cloudinary.utils.ObjectUtils
+import com.wafflestudio.toyproject.team4.common.CustomHttp400
+import com.wafflestudio.toyproject.team4.common.CustomHttp502
+import com.wafflestudio.toyproject.team4.core.image.CloudinaryProperties
+import com.wafflestudio.toyproject.team4.core.image.api.response.ImageUploadResponse
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+import java.util.*
+
+@Service
+@EnableConfigurationProperties(CloudinaryProperties::class)
+class ImageService(
+    cloudinaryProperties: CloudinaryProperties
+) {
+    val cloudinary = Cloudinary(cloudinaryProperties.apiEnvironment)
+
+    fun uploadImages(images: List<MultipartFile>): ImageUploadResponse {
+        try {
+            val secureImages = images.map {
+                val base64Code = Base64.getEncoder().encodeToString(it.bytes)
+                val base64DataUri = "data:image/png;base64,$base64Code"
+                val uploadResult = cloudinary.uploader().upload(base64DataUri, ObjectUtils.emptyMap())
+                uploadResult["secure_url"] as String
+            }
+            return ImageUploadResponse(secureImages)
+        } catch (e: RuntimeException) {
+            println(e)
+            throw CustomHttp400("이미지 업로드에 실패했습니다.")
+        } catch (e: Exception) {
+            println(e)
+            throw CustomHttp502("[서버 오류] 이미지 업로드에 실패했습니다.")
+        }
+    }
+} 

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
@@ -7,8 +7,6 @@ import com.wafflestudio.toyproject.team4.core.user.api.request.LoginRequest
 import com.wafflestudio.toyproject.team4.core.user.api.request.NicknameRequest
 import com.wafflestudio.toyproject.team4.core.user.api.request.RegisterRequest
 import com.wafflestudio.toyproject.team4.core.user.api.request.UsernameRequest
-import com.wafflestudio.toyproject.team4.core.user.api.response.NicknameResponse
-import com.wafflestudio.toyproject.team4.core.user.api.response.UsernameResponse
 import com.wafflestudio.toyproject.team4.core.user.service.AuthService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -26,7 +24,7 @@ class AuthController(
     fun register(
         @RequestBody registerRequest: RegisterRequest
     ) = ResponseEntity(authService.register(registerRequest), HttpStatus.CREATED)
-    
+
     @PostMapping("/login")
     fun login(
         @RequestBody loginRequest: LoginRequest
@@ -46,14 +44,10 @@ class AuthController(
     @PostMapping("/username")
     fun checkDuplicatedUsername(
         @RequestBody usernameRequest: UsernameRequest
-    ): UsernameResponse {
-        return authService.checkDuplicatedUsername(usernameRequest)
-    }
+    ) = authService.checkDuplicatedUsername(usernameRequest)
 
     @PostMapping("/nickname")
     fun checkDuplicatedNickname(
         @RequestBody nicknameRequest: NicknameRequest
-    ): NicknameResponse {
-        return authService.checkDuplicatedNickname(nicknameRequest)
-    }
+    ) = authService.checkDuplicatedNickname(nicknameRequest)
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -38,6 +38,9 @@ auth.jwt:
   jwtExpiration: 900
   refreshExpiration: 3600
 
+cloudinary:
+  apiEnvironment: ${cloudinary-key}
+
 ---
 
 server:


### PR DESCRIPTION
POST /api/image-upload 구현 완료했습니다.
일전에 말씀드린 대로 Cloudinary라는 이미지 서버를 사용했습니다.
Flow는 다음과 같습니다.

1. Client가 JSON이 아닌 FormData 형태로 본인의 로컬 이미지 파일(들)을 Request에 담아 `POST /api/image-upload` 요청
2. Cloudinary에 해당 이미지 업로드 후 `secure_url` 반환
3. 반환된 secure_url을 client에 전송
```json
{
  "secureImages": [
    "https://res.cloudinary.com/dehnixjg0/image/upload/v1673766136/nkwkf3r2q7choig0i2np.png",
    "https://res.cloudinary.com/dehnixjg0/image/upload/v1673766138/nhpujy60aq2rbh3sb5hx.png",
    "https://res.cloudinary.com/dehnixjg0/image/upload/v1673766140/ljoyihjd4p0ctmprpsyi.png",
    ...
  ]
}
```
4. client는 전송받은 secure_url을 게시글 관련 API의 request body에 포함하여 요청
5. 백엔드는 image(s) 필드의 이미지 URL을 안심하고 DB에 저장 또는 client에 전달

프론트-백을 두 번 왕복하지 않고 1번 단계에서 한 번에 처리할 수도 있을 것 같긴 합니다만, 이미지 업로드만을 위한 API를 따로 분리함으로써 범용성을 높이고 다른 API 구현 시 별다른 처리가 필요없다는 점에서 위와 같은 흐름으로 일단 구현했습니다. 추후 수정이 필요하면 논의 후 수정해보도록 하겠습니다.

### ❗️실행 시 IntelliJ 환경변수 설정이 필요합니다
![image](https://user-images.githubusercontent.com/74580163/212529122-1895eb13-44b4-4c42-89c5-67a8c4fb29ec.png)

![image](https://user-images.githubusercontent.com/74580163/212529161-e8057136-2482-4e56-9874-dbea7d6892a0.png)

![image](https://user-images.githubusercontent.com/74580163/212529193-9239974c-d4e9-4cca-b44b-8298ebe35509.png)

![image](https://user-images.githubusercontent.com/74580163/212529205-927a447e-5efa-4bc6-b90c-3dd4af15124a.png)

Environment variables에 다음과 같이 입력 후 Apply -> OK
`cloudinary-key={Notion 홈페이지(MUSIN4)에 나와있는 cloudinary-key}`
ex) `cloudinary-key=cloudinary://122...jg0`