### PR TITLE
Add POST /api/user/me/recently-viewed

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/UserController.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.toyproject.team4.common.Authenticated
 import com.wafflestudio.toyproject.team4.common.UserContext
 import com.wafflestudio.toyproject.team4.core.user.api.request.PatchShoppingCartRequest
 import com.wafflestudio.toyproject.team4.core.user.api.request.PostShoppingCartRequest
+import com.wafflestudio.toyproject.team4.core.user.api.request.RecentlyViewedRequest
 import com.wafflestudio.toyproject.team4.core.user.service.UserService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -75,4 +76,15 @@ class UserController(
         @RequestHeader(value = "Authorization") authorization: String,
         @UserContext username: String,
     ) = ResponseEntity(userService.getRecentlyViewed(username), HttpStatus.OK)
+
+    @Authenticated
+    @PostMapping("/me/recently-viewed")
+    fun postRecentlyViewed(
+        @RequestHeader(value = "Authorization") authorization: String,
+        @UserContext username: String,
+        @RequestBody postRecentlyViewedRequest: RecentlyViewedRequest
+    ) = ResponseEntity(
+        userService.postRecentlyViewed(username, postRecentlyViewedRequest.itemId),
+        HttpStatus.CREATED
+    )
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/request/RecentlyViewedRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/request/RecentlyViewedRequest.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.toyproject.team4.core.user.api.request
+
+data class RecentlyViewedRequest(
+    val itemId: Long
+)

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/RecentItemRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/RecentItemRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
 
 interface RecentItemRepository : JpaRepository<RecentItemEntity, Long>, RecentItemRepositoryCustom {
-    fun findAllByUser(userEntity: UserEntity): List<RecentItemEntity>
+    fun findAllByUserOrderByViewedDateTimeDesc(user: UserEntity): List<RecentItemEntity>
 }
 
 interface RecentItemRepositoryCustom

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/database/UserEntity.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.toyproject.team4.core.user.database
 
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
 import com.wafflestudio.toyproject.team4.core.user.domain.User
 import com.wafflestudio.toyproject.team4.oauth.entity.ProviderType
 import org.springframework.data.annotation.CreatedDate
@@ -53,4 +54,11 @@ class UserEntity(
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
     var recentItems: MutableList<RecentItemEntity> = mutableListOf()
+
+    fun viewItem(
+        item: ItemEntity
+    ) {
+        val recentItem = RecentItemEntity(this, item)
+        recentItems.add(recentItem)
+    }
 }


### PR DESCRIPTION
프론트에서 POST 요청을 보낼 때마다 새로운 행으로 쌓이게끔 구현했습니다.
- 그런데, 프론트 측에서 POST 요청이 동시에 2개가 와서, 아래와 같이 행이 2개씩 쌓이는 문제가 생깁니다
   ![image](https://user-images.githubusercontent.com/90292371/213341732-b828afa2-9680-4d15-a0c8-694f0b815061.png)

   + 처음에는, 어차피 유저별로 최근 본 상품을 최대 12개씩만 보여주면 되니, 유저의 recentItems 리스트 안에 이미 조회한 상품이 있으면 recent_items 테이블에서 그 상품에 해당하는 행의 `viewedDateTime`을 업데이트하는 식으로 코드를 작성하려고 했습니다.
   + 그런데, POST 요청이 거의 동시에 와서 두 번째 POST 요청 시 update가 이루어지지 않고 insert가 이루어집니다.
      : 원래 생각했던 방식은, 첫 POST 요청 시 insert > 두 번째 POST 요청 시 update 가 일어나게 하여 행이 2개씩 쌓이는 문제를 해결하려 했는데, POST 요청이 거의 동시에 이루어져서 두 번째 POST 요청에서도 update가 아닌 insert로 실행되더라고요 ㅜㅜ
      : 그래서 우선은 .. 지금 PR 올린 것과 같이 POST 요청 시마다 계속해서 행이 쌓이게끔 작성해뒀습니다.
- 최근 본 상품을 쿠키나 세션을 사용하는 방식으로도 고민해봤는데, 현 무신사 페이지가 로그아웃 후 재로그인 시에도 이전의 최근 본 상품 기록이 남아있어, 이같이 구현하려면 테이블로 쌓는 방법밖에 없는 것 같아 이같이 구현했습니다.

- 그리고, 위와 같이 최근 본 상품 기록을 쌓게 되면서 GET api에서의 수정도 필요하여 GET 부분도 좀 수정했습니다.
  + 이때, 기존 코드에서는 viewedDateTime으로 내림차순 정렬이 되어 있지 않아, 내림차순 정렬도 하게끔 수정하였습니다.