### PR TITLE
Add /api/auth/social-login

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/api/AuthController.kt
@@ -32,6 +32,12 @@ class AuthController(
         @RequestBody loginRequest: LoginRequest
     ) = authService.login(loginRequest)
 
+    @Authenticated
+    @PostMapping("/social-login")
+    fun socialLogin(
+        @UserContext username: String
+    ) = authService.socialLogin(username)
+
     @PostMapping("/refresh")
     fun refresh(
         @CookieValue(value = "refreshToken") refreshToken: String,

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthTokenService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/user/service/AuthTokenService.kt
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.Date
-import javax.servlet.http.Cookie
 
 @Service
 @EnableConfigurationProperties(AuthProperties::class)
@@ -82,15 +81,6 @@ class AuthTokenService(
             .setSigningKey(signingKey)
             .build()
             .parseClaimsJws(prefixRemoved)
-    }
-
-    fun generateCookie(token: String): Cookie {
-        val cookie = Cookie("refreshToken", token)
-        cookie.isHttpOnly = true
-        cookie.secure = true
-        cookie.path = "/"
-        cookie.maxAge = 3600
-        return cookie
     }
 
     fun generateResponseCookie(token: String): ResponseCookie {

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/oauth/handler/OAuth2AuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/oauth/handler/OAuth2AuthenticationSuccessHandler.kt
@@ -1,7 +1,5 @@
 package com.wafflestudio.toyproject.team4.oauth.handler
 
-import com.wafflestudio.toyproject.team4.common.CustomHttp404
-import com.wafflestudio.toyproject.team4.core.user.database.UserRepository
 import com.wafflestudio.toyproject.team4.core.user.service.AuthTokenService
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
@@ -11,36 +9,27 @@ import org.springframework.stereotype.Component
 import org.springframework.web.util.UriComponentsBuilder
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import javax.transaction.Transactional
 
 @Component
 class OAuth2AuthenticationSuccessHandler(
-    val authTokenService: AuthTokenService,
-    val userRepository: UserRepository
+    val authTokenService: AuthTokenService
 ) : SimpleUrlAuthenticationSuccessHandler() {
-    @Transactional
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,
         response: HttpServletResponse,
         authentication: Authentication
     ) {
         val oAuth2User: OAuth2User = authentication.principal as OAuth2User
-        val providerType = (authentication as OAuth2AuthenticationToken).authorizedClientRegistrationId.uppercase()
-        val username = "$providerType-${oAuth2User.attributes["id"]}"
-        val user = userRepository.findByUsername(username) ?: throw CustomHttp404("해당 아이디로 가입된 사용자 정보가 없습니다.")
-
+        val providerType = (authentication as OAuth2AuthenticationToken).authorizedClientRegistrationId.lowercase()
+        val username = "${providerType}_${oAuth2User.attributes["id"]}"
         val accessToken = authTokenService.generateAccessTokenByUsername(username).accessToken
-        val refreshToken = authTokenService.generateRefreshTokenByUsername(username)
-        user.refreshToken = refreshToken
-        val cookie = authTokenService.generateCookie(refreshToken)
-        response.addCookie(cookie)
-
         val redirectUrl = makeRedirectUrl(accessToken)
         redirectStrategy.sendRedirect(request, response, redirectUrl)
     }
 
     private fun makeRedirectUrl(accessToken: String): String {
-        return UriComponentsBuilder.fromUriString("https://musin4.netlify.app/oauth2/redirect/$accessToken")
-            .build().toUriString()
+        return UriComponentsBuilder.fromUriString(
+            "https://musin4.netlify.app/oauth2/redirect/$accessToken"
+        ).build().toUriString()
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/oauth/info/OAuth2UserInfoFactory.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/oauth/info/OAuth2UserInfoFactory.kt
@@ -7,7 +7,6 @@ object OAuth2UserInfoFactory {
     fun getOAuth2UserInfo(providerType: ProviderType?, attributes: Map<String, Any>): OAuth2UserInfo {
         return when (providerType) {
             ProviderType.KAKAO -> KakaoOAuth2UserInfo(attributes)
-//            ProviderType.APPLE -> AppleOAuth2UserInfo(attributes)
             else -> throw IllegalArgumentException("Invalid Provider Type.")
         }
     }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/oauth/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/oauth/service/CustomOAuth2UserService.kt
@@ -40,7 +40,7 @@ class CustomOAuth2UserService(
                 userRequest.clientRegistration.registrationId.uppercase(Locale.getDefault())
             ) // OAuth 서비스 이름(ex. GITHUB, NAVER, GOOGLE)
         val oAuth2UserId = oAuth2User.attributes["id"]
-        val username = "$providerType-$oAuth2UserId" // Arbitrary username Ex) KAKAO-1294726
+        val username = "${providerType.toString().lowercase()}_$oAuth2UserId" // Arbitrary username Ex) kakao_1294726
         val userInfo: OAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(
             providerType, oAuth2User.attributes
         )


### PR DESCRIPTION
- 배포 서버에서 소셜 로그인이 제대로 이루어지지 않는 문제가 발생하여, 새로운 비동기 API인 `/api/auth/social-login`를 만들어 해결하였습니다. [관련 이슈](https://github.com/wafflestudio20-5/team4-web/issues/43)

- 이외에도 회원가입 시 아이디 및 닉네임 입력 기준에 맞게 소셜 로그인 시 자동으로 생성되는 아이디 및 닉네임을 조금 수정하였습니다.