### PR TITLE
Fix and Refactor `/api/items` and `/api/search`

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -29,10 +29,9 @@ class ItemController(
         @RequestParam subcategory: String?,
         @RequestParam index: Long?,
         @RequestParam count: Long?,
+        @RequestParam sort: String?
     ) = itemService.getItemRankingList(
-        category, subcategory,
-        index ?: 0L, count ?: 20L
-    )
+        category, subcategory, index ?: 0L, count ?: 20L, sort)
 
     @GetMapping("/item/{id}")
     fun getItem(

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -30,7 +30,7 @@ class ItemController(
         @RequestParam index: Long?,
         @RequestParam count: Long?,
         @RequestParam sort: String?
-    ) = itemService.getItemRankingList(category, subcategory, index?: 0L, count?: 20L, sort)
+    ) = itemService.getItemRankingList(category, subcategory, index ?: 0L, count ?: 20L, sort)
 
     @GetMapping("/item/{id}")
     fun getItem(

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/ItemController.kt
@@ -30,8 +30,7 @@ class ItemController(
         @RequestParam index: Long?,
         @RequestParam count: Long?,
         @RequestParam sort: String?
-    ) = itemService.getItemRankingList(
-        category, subcategory, index ?: 0L, count ?: 20L, sort)
+    ) = itemService.getItemRankingList(category, subcategory, index?: 0L, count?: 20L, sort)
 
     @GetMapping("/item/{id}")
     fun getItem(

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/api/response/ItemRankingResponse.kt
@@ -1,7 +1,8 @@
 package com.wafflestudio.toyproject.team4.core.item.api.response
 
-import com.wafflestudio.toyproject.team4.core.item.domain.Item
+import com.wafflestudio.toyproject.team4.core.item.domain.RankingItem
 
 data class ItemRankingResponse(
-    val items: List<Item>
+    val items: List<RankingItem>,
+    val totalPages: Long
 )

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
@@ -2,8 +2,6 @@ package com.wafflestudio.toyproject.team4.core.item.database
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.toyproject.team4.core.item.database.QItemEntity.itemEntity
-import com.wafflestudio.toyproject.team4.core.item.database.QItemImageEntity.itemImageEntity
-import com.wafflestudio.toyproject.team4.core.item.database.QOptionEntity.optionEntity
 import com.wafflestudio.toyproject.team4.core.item.domain.Item
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
@@ -34,14 +32,9 @@ class ItemRepositoryCustomImpl(
         }
 
         return queryFactory
-            .select(itemEntity)
+            .selectDistinct(itemEntity)
             .from(itemEntity)
-            .leftJoin(itemImageEntity)
-            .on(itemImageEntity.item.eq(itemEntity))
-            .fetchJoin()
-            .leftJoin(optionEntity)
-            .on(optionEntity.item.eq(itemEntity))
-            .fetchJoin()
+            .leftJoin(itemEntity.images).fetchJoin()
             .where(eqInterest)
             .orderBy(ordering)
             .fetch()

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
@@ -9,7 +9,11 @@ import org.springframework.stereotype.Component
 interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositoryCustom
 
 interface ItemRepositoryCustom {
-    fun findAllByOrderBy(category: Item.Category?, subCategory: Item.SubCategory?, sort: ItemRepositoryCustomImpl.Sort): List<ItemEntity>
+    fun findAllByOrderBy(
+        category: Item.Category?,
+        subCategory: Item.SubCategory?,
+        sort: ItemRepositoryCustomImpl.Sort
+    ): List<ItemEntity>
     fun findAllByContainingOrderByRatingDesc(query: String): List<ItemEntity>
 }
 
@@ -17,12 +21,20 @@ interface ItemRepositoryCustom {
 class ItemRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory
 ) : ItemRepositoryCustom {
-    override fun findAllByOrderBy(category: Item.Category?, subCategory: Item.SubCategory?, sort: Sort): List<ItemEntity> {
-        val eqInterest = if (category == null && subCategory == null) { null }
-            else if (category != null && subCategory == null) { itemEntity.category.eq(category) }
-            else { itemEntity.subCategory.eq(subCategory) }
+    override fun findAllByOrderBy(
+        category: Item.Category?,
+        subCategory: Item.SubCategory?,
+        sort: Sort
+    ): List<ItemEntity> {
+        val eqInterest =
+            if (category == null && subCategory == null)
+                null
+            else if (category != null && subCategory == null)
+                itemEntity.category.eq(category)
+            else
+                itemEntity.subCategory.eq(subCategory)
 
-        val ordering = when(sort) {
+        val ordering = when (sort) {
             Sort.PRICE -> itemEntity.newPrice.coalesce(itemEntity.oldPrice).asc()
             Sort.PRICE_REVERSE -> itemEntity.newPrice.coalesce(itemEntity.oldPrice).desc()
             Sort.SALE -> itemEntity.sale.desc()
@@ -47,7 +59,7 @@ class ItemRepositoryCustomImpl(
     }
 
     private fun findContainingQuery(field: String, query: String): List<ItemEntity> {
-        val eqInterest = when(field) {
+        val eqInterest = when (field) {
             "name" -> itemEntity.name.contains(query)
             else -> itemEntity.brand.contains(query)
         }
@@ -60,7 +72,6 @@ class ItemRepositoryCustomImpl(
             .orderBy(itemEntity.rating.desc())
             .fetch()
     }
-
 
     enum class Sort {
         PRICE, PRICE_REVERSE, RATING, SALE

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/database/ItemRepository.kt
@@ -1,21 +1,54 @@
 package com.wafflestudio.toyproject.team4.core.item.database
 
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.toyproject.team4.core.item.database.QItemEntity.itemEntity
+import com.wafflestudio.toyproject.team4.core.item.database.QItemImageEntity.itemImageEntity
+import com.wafflestudio.toyproject.team4.core.item.database.QOptionEntity.optionEntity
 import com.wafflestudio.toyproject.team4.core.item.domain.Item
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
 
 interface ItemRepository : JpaRepository<ItemEntity, Long>, ItemRepositoryCustom {
-    fun findAllByCategoryOrderByRatingDesc(category: Item.Category): List<ItemEntity>
-    fun findAllBySubCategoryOrderByRatingDesc(subCategory: Item.SubCategory): List<ItemEntity>
-    fun findAllByOrderByRatingDesc(): List<ItemEntity>
     fun findAllByNameContainingOrderByRatingDesc(query: String): List<ItemEntity>
     fun findAllByBrandContainingOrderByRatingDesc(query: String): List<ItemEntity>
 }
 
-interface ItemRepositoryCustom
+interface ItemRepositoryCustom {
+    fun findAllByOrderBy(category: Item.Category?, subCategory: Item.SubCategory?, sort: ItemRepositoryCustomImpl.Sort): List<ItemEntity>
+}
 
 @Component
 class ItemRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory
-) : ItemRepositoryCustom
+) : ItemRepositoryCustom {
+    override fun findAllByOrderBy(category: Item.Category?, subCategory: Item.SubCategory?, sort: Sort): List<ItemEntity> {
+        val eqInterest = if (category == null && subCategory == null) { null }
+            else if (category != null && subCategory == null) { itemEntity.category.eq(category) }
+            else { itemEntity.subCategory.eq(subCategory) }
+
+        val ordering = when(sort) {
+            Sort.PRICE -> itemEntity.newPrice.coalesce(itemEntity.oldPrice).asc()
+            Sort.PRICE_REVERSE -> itemEntity.newPrice.coalesce(itemEntity.oldPrice).desc()
+            Sort.SALE -> itemEntity.sale.desc()
+            else -> itemEntity.rating.desc()
+        }
+
+        return queryFactory
+            .select(itemEntity)
+            .from(itemEntity)
+            .leftJoin(itemImageEntity)
+            .on(itemImageEntity.item.eq(itemEntity))
+            .fetchJoin()
+            .leftJoin(optionEntity)
+            .on(optionEntity.item.eq(itemEntity))
+            .fetchJoin()
+            .where(eqInterest)
+            .orderBy(ordering)
+            .fetch()
+    }
+
+
+    enum class Sort {
+        PRICE, PRICE_REVERSE, RATING, SALE
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/RankingItem.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/RankingItem.kt
@@ -14,6 +14,7 @@ data class RankingItem(
     val sale: Long? = null,
     val reviewCount: Long, // 후기 순 정렬 위함
     val rating: Double?,   // 별점 순 정렬 위함
+    val sex: String,
     val category: String,
     val subCategory: String,
 ) {
@@ -31,6 +32,7 @@ data class RankingItem(
                 sale = sale,
                 reviewCount = reviewCount!!,
                 rating = rating,
+                sex = sex.toString().lowercase(),
                 category = CaseUtils.toCamelCase(category.toString(), false, '_'),
                 subCategory = CaseUtils.toCamelCase(subCategory.toString(), false, '_')
             )

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/RankingItem.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/domain/RankingItem.kt
@@ -1,0 +1,39 @@
+package com.wafflestudio.toyproject.team4.core.item.domain
+
+import com.wafflestudio.toyproject.team4.core.item.database.ItemEntity
+import org.apache.commons.text.CaseUtils
+
+data class RankingItem(
+    val id: Long,
+    val name: String,
+    val brand: String,
+    val images: List<String>,
+    val label: String? = null,
+    val oldPrice: Long,
+    val newPrice: Long? = null,
+    val sale: Long? = null,
+    val reviewCount: Long, // 후기 순 정렬 위함
+    val rating: Double?,   // 별점 순 정렬 위함
+    val category: String,
+    val subCategory: String,
+) {
+
+    companion object {
+        fun of(entity: ItemEntity) = entity.run {
+            RankingItem(
+                id = id,
+                name = name,
+                brand = brand,
+                images = images.map { it.imageUrl },
+                label = label?.toString()?.lowercase(),
+                oldPrice = oldPrice,
+                newPrice = newPrice,
+                sale = sale,
+                reviewCount = reviewCount!!,
+                rating = rating,
+                category = CaseUtils.toCamelCase(category.toString(), false, '_'),
+                subCategory = CaseUtils.toCamelCase(subCategory.toString(), false, '_')
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -22,7 +22,9 @@ import org.springframework.transaction.annotation.Transactional
 import kotlin.math.ceil
 
 interface ItemService {
-    fun getItemRankingList(category: String?, subCategory: String?, index: Long, count: Long, sort: String?): ItemRankingResponse
+    fun getItemRankingList(
+        category: String?, subCategory: String?, index: Long, count: Long, sort: String?
+    ): ItemRankingResponse
     fun getItem(itemId: Long): ItemResponse
     fun getItemReviews(itemId: Long, index: Long, count: Long): ReviewsResponse
     fun getItemInquiries(itemId: Long, index: Long, count: Long): InquiriesResponse
@@ -37,24 +39,26 @@ class ItemServiceImpl(
     private val itemRepository: ItemRepository,
     private val reviewRepository: ReviewRepository,
     private val inquiryRepository: InquiryRepository
-) : ItemService {
+): ItemService {
     @Transactional(readOnly = true)
-    override fun getItemRankingList(category: String?, subCategory: String?, index: Long, count: Long, sort: String?) : ItemRankingResponse {
+    override fun getItemRankingList(
+        category: String?, subCategory: String?, index: Long, count: Long, sort: String?
+    ): ItemRankingResponse {
         val itemCategory = category?.let { Item.Category.valueOf(camelToUpper(it)) }
         val itemSubCategory = subCategory?.let { Item.SubCategory.valueOf(camelToUpper(it)) }
-        val sortingMethod = ItemRepositoryCustomImpl.Sort.valueOf(camelToUpper(sort?: "rating"))
+        val sortingMethod = ItemRepositoryCustomImpl.Sort.valueOf(camelToUpper(sort ?: "rating"))
 
         val rankingList = itemRepository.findAllByOrderBy(itemCategory, itemSubCategory, sortingMethod)
 
         return ItemRankingResponse(
             items = rankingList
-                .filterIndexed { idx, _ -> (idx / count) == index}
+                .filterIndexed { idx, _ -> (idx / count) == index }
                 .map { entity -> RankingItem.of(entity) },
             totalPages = ceil(rankingList.size.toDouble() / count).toLong()
         )
     }
 
-    private fun camelToUpper(camelCaseWord: String): String{
+    private fun camelToUpper(camelCaseWord: String): String {
         return """([a-z])([A-Z]+)""".toRegex().replace(camelCaseWord, "$1_$2").uppercase()
     }
 

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -19,7 +19,7 @@ import com.wafflestudio.toyproject.team4.core.user.database.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import kotlin.math.floor
+import kotlin.math.ceil
 
 interface ItemService {
     fun getItemRankingList(category: String?, subCategory: String?, index: Long, count: Long, sort: String?): ItemRankingResponse
@@ -50,7 +50,7 @@ class ItemServiceImpl(
             items = rankingList
                 .filterIndexed { idx, _ -> (idx / count) == index}
                 .map { entity -> RankingItem.of(entity) },
-            totalPages = floor(rankingList.size.toDouble() / count).toLong()
+            totalPages = ceil(rankingList.size.toDouble() / count).toLong()
         )
     }
 
@@ -96,20 +96,13 @@ class ItemServiceImpl(
     }
 
     override fun searchItemByQuery(query: String, index: Long, count: Long): ItemRankingResponse {
-        val itemList = with(itemRepository) {
-            val itemsSearchedByName = this.findAllByNameContainingOrderByRatingDesc(query)
-            val itemSearchedByBrand = this.findAllByBrandContainingOrderByRatingDesc(query)
-
-            // to give high priority to the results searched by name(=itemsSearchedByName),
-            // simply add the results searched by brand(=itemsSearchedByBrand) afterwards
-            itemsSearchedByName + itemSearchedByBrand
-        }
+        val itemList = itemRepository.findAllByContainingOrderByRatingDesc(query)
 
         return ItemRankingResponse(
             items = itemList
                 .filterIndexed { idx, _ -> (idx / count) == index }
                 .map { entity -> RankingItem.of(entity) },
-            totalPages = floor(itemList.size.toDouble() / count).toLong()
+            totalPages = ceil(itemList.size.toDouble() / count).toLong()
         )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/team4/core/item/service/ItemService.kt
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface ItemService {
-    fun getItemRankingList(category: String?, subCategory: String?, index: Long, count: Long): ItemRankingResponse
+    fun getItemRankingList(category: String?, subCategory: String?, index: Long, count: Long, sort: String?): ItemRankingResponse
     fun getItem(itemId: Long): ItemResponse
     fun getItemReviews(itemId: Long, index: Long, count: Long): ReviewsResponse
     fun getItemInquiries(itemId: Long, index: Long, count: Long): InquiriesResponse
@@ -36,12 +36,7 @@ class ItemServiceImpl(
     private val inquiryRepository: InquiryRepository
 ) : ItemService {
     @Transactional(readOnly = true)
-    override fun getItemRankingList(
-        category: String?,
-        subCategory: String?,
-        index: Long,
-        count: Long
-    ): ItemRankingResponse {
+    override fun getItemRankingList(category: String?, subCategory: String?, index: Long, count: Long, sort: String?) : ItemRankingResponse {
         val rankingList = with(itemRepository) {
             if (category.isNullOrEmpty() && subCategory.isNullOrEmpty()) { // all items
                 findAllByOrderByRatingDesc()


### PR DESCRIPTION
### ✅ `/api/items` 수정 사항
1. `sort` param 추가
2. **queryDSL** 활용함으로써 쿼리 최적화 시도
    - N+1 문제의 해결을 위해 **fetchJoin**을 활용했는데요. 이때, 1:N 관계에 있는 테이블에 대해서 fetchJoin을 동시에 두 개 이상 사용할 수 없다는 문제가 있었습니다.
      + 즉, item 테이블이 item_images와도 1:N 관계이고, item_options와도 1:N 관계에 있어, 동시에 `images`와 `options` 필드에 대해 fetchJoin을 적용할 수 없었습니다.
   - 고민 끝에, 아이템 리스트 페이지(랭킹/검색 화면)에서는 option 정보가 필요 없어서, 위 두 api의 response body에서 `option` 필드를 제거하는 방식을 택했습니다.
3. 페이지네이션 시도
    - 페이지네이션의 경우, 지금처럼 `index`, `count`를 활용하여 해당 페이지에 노출되어야 할 상품들을 리스트 형태로 내보내는 것으로 (+전체 페이지 수 전달) 충분하지 않을까 싶습니다. 
    - 보통 페이지네이션을 하면 `Page` class를 이용하는 듯 했는데, 이 타입의 return type이 아래 사진과 같더라고요. <br>
      ![image](https://user-images.githubusercontent.com/90292371/214306814-1b001538-783f-4410-8e15-c1c5d38b6f37.png)
    - 위 사진처럼 프론트 측에 response body가 전달되고, 이를 토대로 프론트에서 페이지네이션을 위한 작업을 한다고 생각해보면은, 아래와 같이 response body를 내보내주는 것과 차이점이 과연 존재할까 싶었습니다.
        ```
        {
            "items": [
                {
	            },
	            {		    
	            }, ...
             ],
            "totalPages" : number      # 총 페이지 수
        }
        ```
    - 그래서 우선은 기존의 방식을 유지하여 위의 response body를 내보내도록 구현해뒀는데, 만약 추가적인 의견 있으시면 편하게 말씀해주세요 !

---

### ✅ `api/search` 수정사항
`api/items`에서 쿼리 최적화 & 페이지네이션 작업하면서, 이 api에 대해서도 작업해두면 좋을 것 같아 쿼리 최적화 & 페이지네이션 작업 해두었습니다.